### PR TITLE
Fix joint limits in velocity mode

### DIFF
--- a/src/generic_hw_interface.cpp
+++ b/src/generic_hw_interface.cpp
@@ -216,6 +216,11 @@ void GenericHWInterface::registerJointLimits(const hardware_interface::JointHand
 
     joint_position_lower_limits_[joint_id] = joint_limits.min_position;
     joint_position_upper_limits_[joint_id] = joint_limits.max_position;
+
+    // Enforce limits to not start simulation in invalid state
+    joint_position_[joint_id] =
+      joint_limits_interface::internal::saturate(joint_position_[joint_id],
+          joint_limits.min_position, joint_limits.max_position);
   }
 
   // Copy velocity limits if available

--- a/src/sim_hw_interface.cpp
+++ b/src/sim_hw_interface.cpp
@@ -121,7 +121,18 @@ void SimHWInterface::write(ros::Duration &elapsed_time)
 void SimHWInterface::enforceLimits(ros::Duration &period)
 {
   // Enforces position and velocity
-  pos_jnt_sat_interface_.enforceLimits(period);
+  switch (sim_control_mode_)
+  {
+    case 0:   // hardware_interface::MODE_POSITION:
+      pos_jnt_sat_interface_.enforceLimits(period);
+      break;
+    case 1:  // hardware_interface::MODE_VELOCITY:
+      vel_jnt_sat_interface_.enforceLimits(period);
+      break;
+    case 2:  // hardware_interface::MODE_EFFORT:
+      ROS_ERROR_STREAM_NAMED(name_, "Effort not implemented yet");
+      break;
+  }
 }
 
 void SimHWInterface::positionControlSimulation(ros::Duration &elapsed_time, const std::size_t joint_id)


### PR DESCRIPTION
This pull request addressed two issues:
- initial joint positions are not checked for violating joint limits
- in velocity-resolved simulation mode, joint limits are not enforced

I discussed the issue and my suggested fix in davetcoleman/ros_control_boilerplate#8

This fix needs an additional fix to ```joint_limit_interface::VelocityJointSaturationHandle::enforceLimits()```. I already opened a pull request for that: ros-controls/ros_control#264