### PR TITLE
Typo in the readme

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ros_control_boilerplate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Changed boost::shared_ptr to typedef for Lunar support
+* Implemented simulated velocity control
+* Contributors: Dave Coleman
+
 0.4.0 (2016-06-29)
 ------------------
 * Depend on Eigen3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ros_control_boilerplate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.4.0 (2016-06-29)
+------------------
 * Depend on Eigen3
 * Remove dependency on meta package
 * Fixed var name

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ros_control_boilerplate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.4.1 (2017-06-20)
+------------------
 * Changed boost::shared_ptr to typedef for Lunar support
 * Implemented simulated velocity control
 * Contributors: Dave Coleman

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package ros_control_boilerplate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Depend on Eigen3
+* Remove dependency on meta package
+* Fixed var name
+* Contributors: Dave Coleman
+
 0.3.1 (2016-01-13)
 ------------------
 * API deprecation fix for rosparam_shortcuts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Gflags REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -52,6 +53,8 @@ catkin_package(
 ###########
 ## Build ##
 ###########
+
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
 
 include_directories(
   include/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Simple simulation interface and template for setting up a hardware interface for
 
 Developed by [Dave Coleman](http://dav.ee/) at the University of Colorado Boulder
 
+<a href='https://ko-fi.com/A7182AMW' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi2.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+
  * [![Build Status](https://travis-ci.org/davetcoleman/ros_control_boilerplate.svg)](https://travis-ci.org/davetcoleman/ros_control_boilerplate) Travis CI
  * [![Devel Job Status](http://jenkins.ros.org/buildStatus/icon?job=devel-indigo-ros_control_boilerplate)](http://jenkins.ros.org/job/devel-indigo-ros_control_boilerplate) Devel Job Status
  * [![Build Status](http://jenkins.ros.org/buildStatus/icon?job=ros-indigo-ros-control-boilerplate_binarydeb_trusty_amd64)](http://jenkins.ros.org/job/ros-indigo-ros-control-boilerplate_binarydeb_trusty_amd64/) AMD64 Debian Job Status

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then, either install this package from source so you can develop off of it, or i
 
 This package is setup to run the "RRBot" two joint revolute-revolute robot demo. This "template package" is located in the ros_control_boilerplate as a subfolder that you can easily rename and reuse. To run its ros_control non-physics-based simulated hardware interface, run:
 
-    roslaunch ros_control_boilerplate rrbot_simulaton.launch
+    roslaunch ros_control_boilerplate rrbot_simulation.launch
 
 To visualize its published ``/tf`` coordinate transforms in Rviz run:
 

--- a/include/ros_control_boilerplate/sim_hw_interface.h
+++ b/include/ros_control_boilerplate/sim_hw_interface.h
@@ -82,6 +82,9 @@ protected:
   // For position controller to estimate velocity
   std::vector<double> joint_position_prev_;
 
+  // Send commands in different modes
+  int sim_control_mode_ = 0;
+
 };  // class
 
 }  // namespace

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>ros_control_boilerplate</name>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <description>Simple simulation interface and template for setting up a hardware interface for ros_control</description>
 
   <maintainer email="davetcoleman@gmail.com">Dave Coleman</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -34,7 +34,6 @@
 
   <run_depend>hardware_interface</run_depend>
   <run_depend>controller_manager</run_depend>
-  <run_depend>ros_controllers</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>control_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>ros_control_boilerplate</name>
-  <version>0.3.1</version>
+  <version>0.4.0</version>
   <description>Simple simulation interface and template for setting up a hardware interface for ros_control</description>
 
   <maintainer email="davetcoleman@gmail.com">Dave Coleman</maintainer>

--- a/rrbot_control/config/rrbot_controllers.yaml
+++ b/rrbot_control/config/rrbot_controllers.yaml
@@ -9,6 +9,7 @@ hardware_interface:
    joints:
       - joint1
       - joint2
+   sim_control_mode: 1 # 0: position, 1: velocity
 
 # Publish all joint states ----------------------------------
 # Creates the /joint_states topic necessary in ROS

--- a/src/generic_hw_control_loop.cpp
+++ b/src/generic_hw_control_loop.cpp
@@ -62,8 +62,8 @@ GenericHWControlLoop::GenericHWControlLoop(
   clock_gettime(CLOCK_MONOTONIC, &last_time_);
 
   // Start timer
-  ros::Duration desired_update_freq_ = ros::Duration(1 / loop_hz_);
-  non_realtime_loop_ = nh_.createTimer(desired_update_freq_, &GenericHWControlLoop::update, this);
+  ros::Duration desired_update_freq = ros::Duration(1 / loop_hz_);
+  non_realtime_loop_ = nh_.createTimer(desired_update_freq, &GenericHWControlLoop::update, this);
 }
 
 void GenericHWControlLoop::update(const ros::TimerEvent& e)

--- a/src/generic_hw_interface.cpp
+++ b/src/generic_hw_interface.cpp
@@ -143,7 +143,7 @@ void GenericHWInterface::registerJointLimits(const hardware_interface::JointHand
   }
 
   // Get limits from URDF
-  const boost::shared_ptr<const urdf::Joint> urdf_joint = urdf_model_->getJoint(joint_names_[joint_id]);
+  urdf::JointConstSharedPtr urdf_joint = urdf_model_->getJoint(joint_names_[joint_id]);
 
   // Get main joint limits
   if (urdf_joint == NULL)


### PR DESCRIPTION
There is a typo in the "Run Simulation Demo" part of the readme.md

It says to "roslaunch ros_control_boilerplate rrbot_simulaton.launch" where as the launch file is name "rrbot_simulation.launch" so the current instruction is missing and "i" in the name of the launch file