### PR TITLE
refactor GenericHWControlLoop to a sleep-based loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Gflags REQUIRED)
-find_package(Eigen3 REQUIRED)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -53,8 +52,6 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-
-include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
 
 include_directories(
   include/

--- a/include/ros_control_boilerplate/generic_hw_control_loop.h
+++ b/include/ros_control_boilerplate/generic_hw_control_loop.h
@@ -64,14 +64,14 @@ public:
       ros::NodeHandle& nh,
       boost::shared_ptr<ros_control_boilerplate::GenericHWInterface> hardware_interface);
 
-  /** \brief Timer event
-   *         Note: we do not use the TimerEvent time difference because it does NOT guarantee that
-   * the time source is
-   *         strictly linearly increasing
-   */
-  void update(const ros::TimerEvent& e);
+  // Run the control loop (blocking)
+  void run();
 
 protected:
+
+  // Update funcion called with loop_hz_ rate
+  void update();
+
   // Startup and shutdown of the internal node inside a roscpp program
   ros::NodeHandle nh_;
 
@@ -83,7 +83,6 @@ protected:
   double cycle_time_error_threshold_;
 
   // Timing
-  ros::Timer non_realtime_loop_;
   ros::Duration elapsed_time_;
   double loop_hz_;
   struct timespec last_time_;

--- a/include/ros_control_boilerplate/generic_hw_control_loop.h
+++ b/include/ros_control_boilerplate/generic_hw_control_loop.h
@@ -79,7 +79,7 @@ protected:
   std::string name_ = "generic_hw_control_loop";
 
   // Settings
-  ros::Duration desired_update_freq_;
+  ros::Duration desired_update_period_;
   double cycle_time_error_threshold_;
 
   // Timing

--- a/rrbot_control/src/rrbot_hw_main.cpp
+++ b/rrbot_control/src/rrbot_hw_main.cpp
@@ -56,9 +56,7 @@ int main(int argc, char** argv)
 
   // Start the control loop
   ros_control_boilerplate::GenericHWControlLoop control_loop(nh, rrbot_hw_interface);
-
-  // Wait until shutdown signal recieved
-  ros::waitForShutdown();
+  control_loop.run(); // Blocks until shutdown signal recieved
 
   return 0;
 }

--- a/src/generic_hw_control_loop.cpp
+++ b/src/generic_hw_control_loop.cpp
@@ -62,12 +62,18 @@ GenericHWControlLoop::GenericHWControlLoop(
   clock_gettime(CLOCK_MONOTONIC, &last_time_);
 
   desired_update_period_ = ros::Duration(1 / loop_hz_);
-
-  // Start timer
-  non_realtime_loop_ = nh_.createTimer(desired_update_period_, &GenericHWControlLoop::update, this);
 }
 
-void GenericHWControlLoop::update(const ros::TimerEvent& e)
+void GenericHWControlLoop::run()
+{
+  ros::Rate rate(loop_hz_);
+  while(ros::ok()) {
+    update();
+    rate.sleep();
+  }
+}
+
+void GenericHWControlLoop::update()
 {
   // Get change in time
   clock_gettime(CLOCK_MONOTONIC, &current_time_);

--- a/src/generic_hw_control_loop.cpp
+++ b/src/generic_hw_control_loop.cpp
@@ -61,9 +61,10 @@ GenericHWControlLoop::GenericHWControlLoop(
   // Get current time for use with first update
   clock_gettime(CLOCK_MONOTONIC, &last_time_);
 
+  desired_update_period_ = ros::Duration(1 / loop_hz_);
+
   // Start timer
-  ros::Duration desired_update_freq = ros::Duration(1 / loop_hz_);
-  non_realtime_loop_ = nh_.createTimer(desired_update_freq, &GenericHWControlLoop::update, this);
+  non_realtime_loop_ = nh_.createTimer(desired_update_period_, &GenericHWControlLoop::update, this);
 }
 
 void GenericHWControlLoop::update(const ros::TimerEvent& e)
@@ -77,7 +78,7 @@ void GenericHWControlLoop::update(const ros::TimerEvent& e)
   // time " << elapsed_time_.toSec());
 
   // Error check cycle time
-  const double cycle_time_error = (elapsed_time_ - desired_update_freq_).toSec();
+  const double cycle_time_error = (elapsed_time_ - desired_update_period_).toSec();
   if (cycle_time_error > cycle_time_error_threshold_)
   {
     ROS_WARN_STREAM_NAMED(name_, "Cycle time exceeded error threshold by: "

--- a/src/sim_hw_main.cpp
+++ b/src/sim_hw_main.cpp
@@ -56,9 +56,7 @@ int main(int argc, char** argv)
 
   // Start the control loop
   ros_control_boilerplate::GenericHWControlLoop control_loop(nh, sim_hw_interface);
-
-  // Wait until shutdown signal recieved
-  ros::waitForShutdown();
+  control_loop.run(); // Blocks until shutdown signal recieved
 
   return 0;
 }


### PR DESCRIPTION
using `ros:Timer` (= ROS callbacks) might lead to deadlocks, as reported and discussed in https://github.com/ros-controls/ros_control/issues/265

I am aware that this breaks the API.
As an alternative another thread could be spawed in the `GenericHWControlLoop` constructor, but this feels just wrong ;)