### PR TITLE
test_trajectory:  Read joints list from trajectory controller params

### DIFF
--- a/rrbot_control/launch/rrbot_test_trajectory.launch
+++ b/rrbot_control/launch/rrbot_test_trajectory.launch
@@ -11,7 +11,7 @@
     <!-- Load hardware interface -->
     <node name="test_trajectory" pkg="ros_control_boilerplate" type="test_trajectory"
           output="screen" launch-prefix="$(arg launch_prefix)">
-      <param name="action_topic" value="/rrbot/position_trajectory_controller/follow_joint_trajectory/"/>
+      <param name="trajectory_controller" value="position_trajectory_controller"/>
       <rosparam file="$(find ros_control_boilerplate)/rrbot_control/config/rrbot_controllers.yaml" command="load"/>
     </node>
 

--- a/src/tools/test_trajectory.cpp
+++ b/src/tools/test_trajectory.cpp
@@ -57,21 +57,21 @@ public:
   TestTrajectory()
     : nh_private_("~")
   {
-    std::string action_topic;
-    nh_private_.getParam("action_topic", action_topic);
-    if (action_topic.empty())
+    nh_private_.getParam("trajectory_controller", trajectory_controller);
+    if (trajectory_controller.empty())
     {
       ROS_FATAL_STREAM_NAMED(
           "test_trajectory",
-          "Not follow joint trajectory action topic found on the parameter server");
+          "No joint trajectory controller parameter found on the parameter server");
       exit(-1);
     }
-    ROS_INFO_STREAM_NAMED("test_trajectory", "Connecting to action " << action_topic);
+    ROS_INFO_STREAM_NAMED("test_trajectory",
+                          "Connecting to controller " << trajectory_controller);
 
     // create the action client
     // true causes the client to spin its own thread
     actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> action_client(
-        action_topic, true);
+      trajectory_controller + "/follow_joint_trajectory/", true);
 
     ROS_INFO_NAMED("test_trajetory", "Waiting for action server to start.");
     // wait for the action server to start
@@ -111,7 +111,7 @@ public:
     double max_joint_value = 3.14;
 
     // Get joint names
-    nh_private_.getParam("hardware_interface/joints", joint_names);
+    nh_private_.getParam(trajectory_controller + "/joints", joint_names);
     if (joint_names.size() == 0)
     {
       ROS_FATAL_STREAM_NAMED(
@@ -157,6 +157,10 @@ public:
 private:
   // A shared node handle
   ros::NodeHandle nh_private_;
+
+  // A string containing the 'trajectory_controller' parameter value
+  std::string trajectory_controller;
+
 
 };  // end class
 

--- a/src/tools/test_trajectory.cpp
+++ b/src/tools/test_trajectory.cpp
@@ -160,8 +160,6 @@ private:
 
   // A string containing the 'trajectory_controller' parameter value
   std::string trajectory_controller;
-
-
 };  // end class
 
 // Create boost pointers for this class


### PR DESCRIPTION
If the `hardware_interface/joints` list contains some joints
configured in a trajectory controller, the `test_trajectory` program
exits with an error:

    [ERROR]: Joints on incoming goal don't match the controller joints.
    [ INFO]: Action finished: REJECTED
    [ INFO]: TestTrajectory Finished
    [ INFO]: Shutting down.

The correct list of joints for the trajectory controller can be found
in the `<trajectory_controller_name>/joints` parameter.

Since the `<trajectory_controller_name>/follow_joint_trajectory`
parameter name is already being passed in, this patch simply shortens
that to `<trajectory_controller_name>`, and uses it to construct both
topic names.  Now the trajectory is generated for the correct number
of joints.