### PR TITLE
Make NodeHandle a const reference

### DIFF
--- a/include/ros_control_boilerplate/generic_hw_interface.h
+++ b/include/ros_control_boilerplate/generic_hw_interface.h
@@ -69,7 +69,7 @@ public:
    * \param nh - Node handle for topics.
    * \param urdf - optional pointer to a parsed robot model
    */
-  GenericHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model = NULL);
+  GenericHWInterface(const ros::NodeHandle &nh, urdf::Model *urdf_model = NULL);
 
   /** \brief Destructor */
   virtual ~GenericHWInterface() {}
@@ -158,7 +158,7 @@ public:
 protected:
 
   /** \brief Get the URDF XML from the parameter server */
-  virtual void loadURDF(ros::NodeHandle& nh, std::string param_name);
+  virtual void loadURDF(const ros::NodeHandle& nh, std::string param_name);
 
   // Short name of this class
   std::string name_;

--- a/src/generic_hw_interface.cpp
+++ b/src/generic_hw_interface.cpp
@@ -44,7 +44,7 @@
 
 namespace ros_control_boilerplate
 {
-GenericHWInterface::GenericHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model)
+GenericHWInterface::GenericHWInterface(const ros::NodeHandle &nh, urdf::Model *urdf_model)
   : name_("generic_hw_interface")
   , nh_(nh)
   , use_rosparam_joint_limits_(false)
@@ -301,7 +301,7 @@ std::string GenericHWInterface::printCommandHelper()
   return ss.str();
 }
 
-void GenericHWInterface::loadURDF(ros::NodeHandle &nh, std::string param_name)
+void GenericHWInterface::loadURDF(const ros::NodeHandle &nh, std::string param_name)
 {
   std::string urdf_string;
   urdf_model_ = new urdf::Model();


### PR DESCRIPTION
The classes already make a copy of the NodeHandle so this change only
make the interface more strict. It should not affect the external
behavior of this class.