### PR TITLE
Increase num AsyncSpinners where control loops are instantiated

### DIFF
--- a/rrbot_control/src/rrbot_hw_main.cpp
+++ b/rrbot_control/src/rrbot_hw_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
 
   // NOTE: We run the ROS loop in a separate thread as external calls such
   // as service callbacks to load controllers can block the (main) control loop
-  ros::AsyncSpinner spinner(2);
+  ros::AsyncSpinner spinner(3);
   spinner.start();
 
   // Create the hardware interface specific to your robot

--- a/src/sim_hw_main.cpp
+++ b/src/sim_hw_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
 
   // NOTE: We run the ROS loop in a separate thread as external calls such
   // as service callbacks to load controllers can block the (main) control loop
-  ros::AsyncSpinner spinner(2);
+  ros::AsyncSpinner spinner(3);
   spinner.start();
 
   // Create the hardware interface specific to your robot


### PR DESCRIPTION
With just 2 async spinners, I found that my ros_controllers would often hang upon loading. It would usually hang at `Loading controller: joint_state_controller` (or something similar to that). With 3 async spinners, the problem is gone.

Inspired by this example, which actually uses 4 spinners.  https://github.com/cyborg-x1/ros_control_test/blob/master/src/myrobot.cpp