### PR TITLE
Updated travis ci to melodic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 sudo: required
-dist: trusty
+dist: bionic
 language: generic # Force travis to use its minimal image with default Python settings
+python:
+  - "2.7"
 compiler:
   - gcc
 env:
   global:
     - CATKIN_WS=~/catkin_ws
     - CATKIN_WS_SRC=${CATKIN_WS}/src
-    - CI_ROS_DISTRO="indigo"
+    - CI_ROS_DISTRO="melodic"
 install:
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y python-rosdep python-catkin-tools


### PR DESCRIPTION
All of the travis runs for the last PRs seem to show travis-ci/travis-ci#9361. As indicated there, it could be sufficient to add a line
```yaml
- sudo apt-get install -y dpkg
```
but it might make more sense to switch to a melodic ci for ```melodic-devel```.

I don't have much experience with CI systems, but i guess i'll see if this change works soon...