### PR TITLE
Generalize GenericHWControlLoop to all types of RobotHW

### DIFF
--- a/include/ros_control_boilerplate/generic_hw_control_loop.h
+++ b/include/ros_control_boilerplate/generic_hw_control_loop.h
@@ -38,7 +38,8 @@
 */
 
 #include <time.h>
-#include <ros_control_boilerplate/generic_hw_interface.h>
+#include <controller_manager/controller_manager.h>
+#include <hardware_interface/robot_hw.h>
 
 namespace ros_control_boilerplate
 {
@@ -62,7 +63,7 @@ public:
    */
   GenericHWControlLoop(
       ros::NodeHandle& nh,
-      boost::shared_ptr<ros_control_boilerplate::GenericHWInterface> hardware_interface);
+      boost::shared_ptr<hardware_interface::RobotHW> hardware_interface);
 
   // Run the control loop (blocking)
   void run();
@@ -97,7 +98,7 @@ protected:
   boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
 
   /** \brief Abstract Hardware Interface for your robot */
-  boost::shared_ptr<ros_control_boilerplate::GenericHWInterface> hardware_interface_;
+  boost::shared_ptr<hardware_interface::RobotHW> hardware_interface_;
 
 };  // end class
 

--- a/include/ros_control_boilerplate/generic_hw_interface.h
+++ b/include/ros_control_boilerplate/generic_hw_interface.h
@@ -80,8 +80,14 @@ public:
   /** \brief Read the state from the robot hardware. */
   virtual void read(ros::Duration &elapsed_time) = 0;
 
-  /** \brief Delegate RobotHW::read() calls to read() */
-  virtual void read(const ros::Time& /*time*/, const ros::Duration& period)
+  /** \brief Read the state from the robot hardware
+   *
+   * \note This delegates RobotHW::read() calls to read()
+   *
+   * \param time The current time, currently unused
+   * \param period The time passed since the last call
+   */
+  virtual void read(const ros::Time& /*time*/, const ros::Duration& period) override
   {
     ros::Duration elapsed_time = period;
     read(elapsed_time);
@@ -90,8 +96,14 @@ public:
   /** \brief Write the command to the robot hardware. */
   virtual void write(ros::Duration &elapsed_time) = 0;
 
-  /** \brief Delegate RobotHW::write() calls to write() */
-  virtual void write(const ros::Time& /*time*/, const ros::Duration& period)
+  /** \brief Write the command to the robot hardware
+   *
+   * \note This delegates RobotHW::write() calls to \ref write()
+   *
+   * \param time The current time, currently unused
+   * \param period The time passed since the last call
+   */
+  virtual void write(const ros::Time& /*time*/, const ros::Duration& period) override
   {
     ros::Duration elapsed_time = period;
     write(elapsed_time);

--- a/include/ros_control_boilerplate/generic_hw_interface.h
+++ b/include/ros_control_boilerplate/generic_hw_interface.h
@@ -80,8 +80,22 @@ public:
   /** \brief Read the state from the robot hardware. */
   virtual void read(ros::Duration &elapsed_time) = 0;
 
+  /** \brief Delegate RobotHW::read() calls to read() */
+  virtual void read(const ros::Time& /*time*/, const ros::Duration& period)
+  {
+    ros::Duration elapsed_time = period;
+    read(elapsed_time);
+  }
+
   /** \brief Write the command to the robot hardware. */
   virtual void write(ros::Duration &elapsed_time) = 0;
+
+  /** \brief Delegate RobotHW::write() calls to write() */
+  virtual void write(const ros::Time& /*time*/, const ros::Duration& period)
+  {
+    ros::Duration elapsed_time = period;
+    write(elapsed_time);
+  }
 
   /** \brief Set all members to default values */
   virtual void reset();

--- a/src/generic_hw_control_loop.cpp
+++ b/src/generic_hw_control_loop.cpp
@@ -45,7 +45,7 @@
 namespace ros_control_boilerplate
 {
 GenericHWControlLoop::GenericHWControlLoop(
-    ros::NodeHandle& nh, boost::shared_ptr<ros_control_boilerplate::GenericHWInterface> hardware_interface)
+    ros::NodeHandle& nh, boost::shared_ptr<hardware_interface::RobotHW> hardware_interface)
   : nh_(nh), hardware_interface_(hardware_interface)
 {
   // Create the controller manager
@@ -80,6 +80,7 @@ void GenericHWControlLoop::update()
   elapsed_time_ =
       ros::Duration(current_time_.tv_sec - last_time_.tv_sec + (current_time_.tv_nsec - last_time_.tv_nsec) / BILLION);
   last_time_ = current_time_;
+  ros::Time now = ros::Time::now();
   // ROS_DEBUG_STREAM_THROTTLE_NAMED(1, "generic_hw_main","Sampled update loop with elapsed
   // time " << elapsed_time_.toSec());
 
@@ -93,13 +94,13 @@ void GenericHWControlLoop::update()
   }
 
   // Input
-  hardware_interface_->read(elapsed_time_);
+  hardware_interface_->read(now, elapsed_time_);
 
   // Control
-  controller_manager_->update(ros::Time::now(), elapsed_time_);
+  controller_manager_->update(now, elapsed_time_);
 
   // Output
-  hardware_interface_->write(elapsed_time_);
+  hardware_interface_->write(now, elapsed_time_);
 }
 
 }  // namespace


### PR DESCRIPTION
There is no specific reason why the GenericHWControlLoop should only work with GenericHWInterfaces, as it only needs to call the read() and write() methods of the interface. This change also allows it to be used in a generic runner node for combined_robot_hw, which is useful in #34.