### PR TITLE
Support for combined_robot_hw::CombinedRobotHW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(generic_hw_control_loop
 # Generic Hardware Interface
 add_library(generic_hw_interface
   src/generic_hw_interface.cpp
+  src/combinable_generic_hw_interface.cpp
 )
 target_link_libraries(generic_hw_interface
   ${catkin_LIBRARIES}

--- a/include/ros_control_boilerplate/combinable_generic_hw_interface.h
+++ b/include/ros_control_boilerplate/combinable_generic_hw_interface.h
@@ -1,0 +1,224 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, University of Colorado, Boulder
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Univ of CO, Boulder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman
+   Desc:   Example ros_control hardware interface that performs a perfect control loop for
+   simulation
+*/
+
+#ifndef GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H
+#define GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H
+
+// C++
+#include <boost/scoped_ptr.hpp>
+
+// ROS
+#include <ros/ros.h>
+#include <urdf/model.h>
+
+// ROS Controls
+#include <hardware_interface/robot_hw.h>
+#include <hardware_interface/joint_state_interface.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <controller_manager/controller_manager.h>
+#include <joint_limits_interface/joint_limits.h>
+#include <joint_limits_interface/joint_limits_interface.h>
+#include <joint_limits_interface/joint_limits_rosparam.h>
+#include <joint_limits_interface/joint_limits_urdf.h>
+
+namespace ros_control_boilerplate
+{
+
+/// \brief Hardware interface for a robot
+class CombinableGenericHWInterface : public hardware_interface::RobotHW
+{
+public:
+  /**
+   * \brief Constructor
+   * 
+   * Override _name for your hardware interface so the parameters can be loaded.
+   * Also, override use_rosparam_joint_limits_ & use_soft_limits_if_available_ for your needs.
+   */
+  CombinableGenericHWInterface();
+
+  /** \brief Destructor */
+  virtual ~CombinableGenericHWInterface() {}
+
+  /** \brief The init function is called to initialize the RobotHW from a
+   * non-realtime thread.
+   *
+   * \param root_nh A NodeHandle in the root of the caller namespace.
+   *
+   * \param robot_hw_nh A NodeHandle in the namespace from which the RobotHW
+   * should read its configuration.
+   *
+   * \returns True if initialization was successful
+   */
+  virtual bool init(ros::NodeHandle &root_nh, ros::NodeHandle &robot_hw_nh);
+
+  /** \brief Read the state from the robot hardware. */
+  virtual void read(ros::Duration &elapsed_time) = 0;
+
+  /** \brief Read the state from the robot hardware
+   *
+   * \note This delegates RobotHW::read() calls to read()
+   *
+   * \param time The current time, currently unused
+   * \param period The time passed since the last call
+   */
+  virtual void read(const ros::Time& /*time*/, const ros::Duration& period) override
+  {
+    ros::Duration elapsed_time = period;
+    read(elapsed_time);
+  }
+
+  /** \brief Write the command to the robot hardware. */
+  virtual void write(ros::Duration &elapsed_time) = 0;
+
+  /** \brief Write the command to the robot hardware
+   *
+   * \note This delegates RobotHW::write() calls to \ref write()
+   *
+   * \param time The current time, currently unused
+   * \param period The time passed since the last call
+   */
+  virtual void write(const ros::Time& /*time*/, const ros::Duration& period) override
+  {
+    ros::Duration elapsed_time = period;
+    write(elapsed_time);
+  }
+
+  /** \brief Set all members to default values */
+  virtual void reset();
+
+  /**
+   * \brief Check (in non-realtime) if given controllers could be started and stopped from the
+   * current state of the RobotHW
+   * with regard to necessary hardware interface switches. Start and stop list are disjoint.
+   * This is just a check, the actual switch is done in doSwitch()
+   */
+  virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo> &start_list,
+                         const std::list<hardware_interface::ControllerInfo> &stop_list) const
+  {
+    return true;
+  }
+
+  /**
+   * \brief Perform (in non-realtime) all necessary hardware interface switches in order to start
+   * and stop the given controllers.
+   * Start and stop list are disjoint. The feasability was checked in canSwitch() beforehand.
+   */
+  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list,
+                        const std::list<hardware_interface::ControllerInfo> &stop_list)
+  {
+  }
+
+  /**
+   * \brief Register the limits of the joint specified by joint_id and joint_handle. The limits
+   * are retrieved from the urdf_model.
+   * 
+   * \param nh A NodeHandle in the root of the caller namespace.
+   *
+   * \return the joint's type, lower position limit, upper position limit, and effort limit.
+   */
+  virtual void registerJointLimits(const hardware_interface::JointHandle &joint_handle_position,
+                           const hardware_interface::JointHandle &joint_handle_velocity,
+                           const hardware_interface::JointHandle &joint_handle_effort,
+                           std::size_t joint_id,
+                           const ros::NodeHandle& nh);
+
+  /** \breif Enforce limits for all values before writing */
+  virtual void enforceLimits(ros::Duration &period) = 0;
+
+  /** \brief Helper for debugging a joint's state */
+  virtual void printState();
+  std::string printStateHelper();
+
+  /** \brief Helper for debugging a joint's command */
+  std::string printCommandHelper();
+
+protected:
+
+  /** \brief Get the URDF XML from the parameter server */
+  virtual void loadURDF(const ros::NodeHandle& nh, std::string param_name);
+
+  // Short name of this class
+  std::string name_;
+
+  // Hardware interfaces
+  hardware_interface::JointStateInterface joint_state_interface_;
+  hardware_interface::PositionJointInterface position_joint_interface_;
+  hardware_interface::VelocityJointInterface velocity_joint_interface_;
+  hardware_interface::EffortJointInterface effort_joint_interface_;
+
+  // Joint limits interfaces - Saturation
+  joint_limits_interface::PositionJointSaturationInterface pos_jnt_sat_interface_;
+  joint_limits_interface::VelocityJointSaturationInterface vel_jnt_sat_interface_;
+  joint_limits_interface::EffortJointSaturationInterface eff_jnt_sat_interface_;
+
+  // Joint limits interfaces - Soft limits
+  joint_limits_interface::PositionJointSoftLimitsInterface pos_jnt_soft_limits_;
+  joint_limits_interface::VelocityJointSoftLimitsInterface vel_jnt_soft_limits_;
+  joint_limits_interface::EffortJointSoftLimitsInterface eff_jnt_soft_limits_;
+
+  // Configuration
+  std::vector<std::string> joint_names_;
+  std::size_t num_joints_;
+  urdf::Model *urdf_model_;
+
+  // Modes
+  bool use_rosparam_joint_limits_;
+  bool use_soft_limits_if_available_;
+
+  // States
+  std::vector<double> joint_position_;
+  std::vector<double> joint_velocity_;
+  std::vector<double> joint_effort_;
+
+  // Commands
+  std::vector<double> joint_position_command_;
+  std::vector<double> joint_velocity_command_;
+  std::vector<double> joint_effort_command_;
+
+  // Copy of limits, in case we need them later in our control stack
+  std::vector<double> joint_position_lower_limits_;
+  std::vector<double> joint_position_upper_limits_;
+  std::vector<double> joint_velocity_limits_;
+  std::vector<double> joint_effort_limits_;
+
+};  // class
+
+}  // namespace
+
+#endif // GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H

--- a/include/ros_control_boilerplate/combinable_generic_hw_interface.h
+++ b/include/ros_control_boilerplate/combinable_generic_hw_interface.h
@@ -59,21 +59,22 @@
 
 namespace ros_control_boilerplate
 {
-
 /// \brief Hardware interface for a robot
 class CombinableGenericHWInterface : public hardware_interface::RobotHW
 {
 public:
   /**
    * \brief Constructor
-   * 
+   *
    * Override _name for your hardware interface so the parameters can be loaded.
    * Also, override use_rosparam_joint_limits_ & use_soft_limits_if_available_ for your needs.
    */
   CombinableGenericHWInterface();
 
   /** \brief Destructor */
-  virtual ~CombinableGenericHWInterface() {}
+  virtual ~CombinableGenericHWInterface()
+  {
+  }
 
   /** \brief The init function is called to initialize the RobotHW from a
    * non-realtime thread.
@@ -85,10 +86,10 @@ public:
    *
    * \returns True if initialization was successful
    */
-  virtual bool init(ros::NodeHandle &root_nh, ros::NodeHandle &robot_hw_nh);
+  virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh);
 
   /** \brief Read the state from the robot hardware. */
-  virtual void read(ros::Duration &elapsed_time) = 0;
+  virtual void read(ros::Duration& elapsed_time) = 0;
 
   /** \brief Read the state from the robot hardware
    *
@@ -104,7 +105,7 @@ public:
   }
 
   /** \brief Write the command to the robot hardware. */
-  virtual void write(ros::Duration &elapsed_time) = 0;
+  virtual void write(ros::Duration& elapsed_time) = 0;
 
   /** \brief Write the command to the robot hardware
    *
@@ -128,8 +129,8 @@ public:
    * with regard to necessary hardware interface switches. Start and stop list are disjoint.
    * This is just a check, the actual switch is done in doSwitch()
    */
-  virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo> &start_list,
-                         const std::list<hardware_interface::ControllerInfo> &stop_list) const
+  virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                         const std::list<hardware_interface::ControllerInfo>& stop_list) const
   {
     return true;
   }
@@ -139,27 +140,26 @@ public:
    * and stop the given controllers.
    * Start and stop list are disjoint. The feasability was checked in canSwitch() beforehand.
    */
-  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list,
-                        const std::list<hardware_interface::ControllerInfo> &stop_list)
+  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                        const std::list<hardware_interface::ControllerInfo>& stop_list)
   {
   }
 
   /**
    * \brief Register the limits of the joint specified by joint_id and joint_handle. The limits
    * are retrieved from the urdf_model.
-   * 
+   *
    * \param nh A NodeHandle in the root of the caller namespace.
    *
    * \return the joint's type, lower position limit, upper position limit, and effort limit.
    */
-  virtual void registerJointLimits(const hardware_interface::JointHandle &joint_handle_position,
-                           const hardware_interface::JointHandle &joint_handle_velocity,
-                           const hardware_interface::JointHandle &joint_handle_effort,
-                           std::size_t joint_id,
-                           const ros::NodeHandle& nh);
+  virtual void registerJointLimits(const hardware_interface::JointHandle& joint_handle_position,
+                                   const hardware_interface::JointHandle& joint_handle_velocity,
+                                   const hardware_interface::JointHandle& joint_handle_effort, std::size_t joint_id,
+                                   const ros::NodeHandle& nh);
 
   /** \breif Enforce limits for all values before writing */
-  virtual void enforceLimits(ros::Duration &period) = 0;
+  virtual void enforceLimits(ros::Duration& period) = 0;
 
   /** \brief Helper for debugging a joint's state */
   virtual void printState();
@@ -169,7 +169,6 @@ public:
   std::string printCommandHelper();
 
 protected:
-
   /** \brief Get the URDF XML from the parameter server */
   virtual void loadURDF(const ros::NodeHandle& nh, std::string param_name);
 
@@ -195,7 +194,7 @@ protected:
   // Configuration
   std::vector<std::string> joint_names_;
   std::size_t num_joints_;
-  urdf::Model *urdf_model_;
+  urdf::Model* urdf_model_;
 
   // Modes
   bool use_rosparam_joint_limits_;
@@ -219,6 +218,6 @@ protected:
 
 };  // class
 
-}  // namespace
+}  // namespace ros_control_boilerplate
 
-#endif // GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H
+#endif  // GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H

--- a/src/combinable_generic_hw_interface.cpp
+++ b/src/combinable_generic_hw_interface.cpp
@@ -1,0 +1,331 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman
+   Desc:   Helper ros_control hardware interface that loads configurations
+*/
+
+#include <ros_control_boilerplate/combinable_generic_hw_interface.h>
+#include <limits>
+
+// ROS parameter loading
+#include <rosparam_shortcuts/rosparam_shortcuts.h>
+
+namespace ros_control_boilerplate
+{
+CombinableGenericHWInterface::CombinableGenericHWInterface()
+  : name_("combinable_generic_hardware"), use_rosparam_joint_limits_(false), use_soft_limits_if_available_(false)
+{
+}
+
+bool CombinableGenericHWInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
+{
+  hardware_interface::RobotHW::init(root_nh, robot_hw_nh);
+  // Load URDF
+  loadURDF(root_nh, "robot_description");
+
+  // Load rosparams
+  std::size_t error = 0;
+  error += !rosparam_shortcuts::get(name_, robot_hw_nh, "joints", joint_names_);
+  if (error > 0)
+    return false;
+  num_joints_ = joint_names_.size();
+
+  // Status
+  joint_position_.resize(num_joints_, 0.0);
+  joint_velocity_.resize(num_joints_, 0.0);
+  joint_effort_.resize(num_joints_, 0.0);
+
+  // Command
+  joint_position_command_.resize(num_joints_, 0.0);
+  joint_velocity_command_.resize(num_joints_, 0.0);
+  joint_effort_command_.resize(num_joints_, 0.0);
+
+  // Limits
+  joint_position_lower_limits_.resize(num_joints_, 0.0);
+  joint_position_upper_limits_.resize(num_joints_, 0.0);
+  joint_velocity_limits_.resize(num_joints_, 0.0);
+  joint_effort_limits_.resize(num_joints_, 0.0);
+
+  // Initialize interfaces for each joint
+  for (std::size_t joint_id = 0; joint_id < num_joints_; ++joint_id)
+  {
+    ROS_DEBUG_STREAM_NAMED(name_, "Loading joint name: " << joint_names_[joint_id]);
+
+    // Create joint state interface
+    joint_state_interface_.registerHandle(hardware_interface::JointStateHandle(
+        joint_names_[joint_id], &joint_position_[joint_id], &joint_velocity_[joint_id], &joint_effort_[joint_id]));
+
+    // Add command interfaces to joints
+    // TODO: decide based on transmissions?
+    hardware_interface::JointHandle joint_handle_position = hardware_interface::JointHandle(
+        joint_state_interface_.getHandle(joint_names_[joint_id]), &joint_position_command_[joint_id]);
+    position_joint_interface_.registerHandle(joint_handle_position);
+
+    hardware_interface::JointHandle joint_handle_velocity = hardware_interface::JointHandle(
+        joint_state_interface_.getHandle(joint_names_[joint_id]), &joint_velocity_command_[joint_id]);
+    velocity_joint_interface_.registerHandle(joint_handle_velocity);
+
+    hardware_interface::JointHandle joint_handle_effort = hardware_interface::JointHandle(
+        joint_state_interface_.getHandle(joint_names_[joint_id]), &joint_effort_command_[joint_id]);
+    effort_joint_interface_.registerHandle(joint_handle_effort);
+
+    // Load the joint limits
+    registerJointLimits(joint_handle_position, joint_handle_velocity, joint_handle_effort, joint_id, root_nh);
+  }  // end for each joint
+
+  registerInterface(&joint_state_interface_);     // From RobotHW base class.
+  registerInterface(&position_joint_interface_);  // From RobotHW base class.
+  registerInterface(&velocity_joint_interface_);  // From RobotHW base class.
+  registerInterface(&effort_joint_interface_);    // From RobotHW base class.
+
+  ROS_INFO_STREAM_NAMED(name_, "CombinableGenericHWInterface Ready.");
+  return true;
+}
+
+void CombinableGenericHWInterface::registerJointLimits(const hardware_interface::JointHandle& joint_handle_position,
+                                                       const hardware_interface::JointHandle& joint_handle_velocity,
+                                                       const hardware_interface::JointHandle& joint_handle_effort,
+                                                       std::size_t joint_id, const ros::NodeHandle& nh)
+{
+  // Default values
+  joint_position_lower_limits_[joint_id] = -std::numeric_limits<double>::max();
+  joint_position_upper_limits_[joint_id] = std::numeric_limits<double>::max();
+  joint_velocity_limits_[joint_id] = std::numeric_limits<double>::max();
+  joint_effort_limits_[joint_id] = std::numeric_limits<double>::max();
+
+  // Limits datastructures
+  joint_limits_interface::JointLimits joint_limits;     // Position
+  joint_limits_interface::SoftJointLimits soft_limits;  // Soft Position
+  bool has_joint_limits = false;
+  bool has_soft_limits = false;
+
+  // Get limits from URDF
+  if (urdf_model_ == NULL)
+  {
+    ROS_WARN_STREAM_NAMED(name_, "No URDF model loaded, unable to get joint limits");
+    return;
+  }
+
+  // Get limits from URDF
+  urdf::JointConstSharedPtr urdf_joint = urdf_model_->getJoint(joint_names_[joint_id]);
+
+  // Get main joint limits
+  if (urdf_joint == NULL)
+  {
+    ROS_ERROR_STREAM_NAMED(name_, "URDF joint not found " << joint_names_[joint_id]);
+    return;
+  }
+
+  // Get limits from URDF
+  if (joint_limits_interface::getJointLimits(urdf_joint, joint_limits))
+  {
+    has_joint_limits = true;
+    ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " has URDF position limits ["
+                                           << joint_limits.min_position << ", " << joint_limits.max_position << "]");
+    if (joint_limits.has_velocity_limits)
+      ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " has URDF velocity limit ["
+                                             << joint_limits.max_velocity << "]");
+  }
+  else
+  {
+    if (urdf_joint->type != urdf::Joint::CONTINUOUS)
+      ROS_WARN_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id]
+                                            << " does not have a URDF "
+                                               "position limit");
+  }
+
+  // Get limits from ROS param
+  if (use_rosparam_joint_limits_)
+  {
+    if (joint_limits_interface::getJointLimits(joint_names_[joint_id], nh, joint_limits))
+    {
+      has_joint_limits = true;
+      ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " has rosparam position limits ["
+                                             << joint_limits.min_position << ", " << joint_limits.max_position << "]");
+      if (joint_limits.has_velocity_limits)
+        ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " has rosparam velocity limit ["
+                                               << joint_limits.max_velocity << "]");
+    }  // the else debug message provided internally by joint_limits_interface
+  }
+
+  // Get soft limits from URDF
+  if (use_soft_limits_if_available_)
+  {
+    if (joint_limits_interface::getSoftJointLimits(urdf_joint, soft_limits))
+    {
+      has_soft_limits = true;
+      ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " has soft joint limits.");
+    }
+    else
+    {
+      ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id]
+                                             << " does not have soft joint "
+                                                "limits");
+    }
+  }
+
+  // Quit we we haven't found any limits in URDF or rosparam server
+  if (!has_joint_limits)
+  {
+    return;
+  }
+
+  // Copy position limits if available
+  if (joint_limits.has_position_limits)
+  {
+    // Slighly reduce the joint limits to prevent floating point errors
+    joint_limits.min_position += std::numeric_limits<double>::epsilon();
+    joint_limits.max_position -= std::numeric_limits<double>::epsilon();
+
+    joint_position_lower_limits_[joint_id] = joint_limits.min_position;
+    joint_position_upper_limits_[joint_id] = joint_limits.max_position;
+  }
+
+  // Copy velocity limits if available
+  if (joint_limits.has_velocity_limits)
+  {
+    joint_velocity_limits_[joint_id] = joint_limits.max_velocity;
+  }
+
+  // Copy effort limits if available
+  if (joint_limits.has_effort_limits)
+  {
+    joint_effort_limits_[joint_id] = joint_limits.max_effort;
+  }
+
+  if (has_soft_limits)  // Use soft limits
+  {
+    ROS_DEBUG_STREAM_NAMED(name_, "Using soft saturation limits");
+    const joint_limits_interface::PositionJointSoftLimitsHandle soft_handle_position(joint_handle_position,
+                                                                                     joint_limits, soft_limits);
+    pos_jnt_soft_limits_.registerHandle(soft_handle_position);
+    const joint_limits_interface::VelocityJointSoftLimitsHandle soft_handle_velocity(joint_handle_velocity,
+                                                                                     joint_limits, soft_limits);
+    vel_jnt_soft_limits_.registerHandle(soft_handle_velocity);
+    const joint_limits_interface::EffortJointSoftLimitsHandle soft_handle_effort(joint_handle_effort, joint_limits,
+                                                                                 soft_limits);
+    eff_jnt_soft_limits_.registerHandle(soft_handle_effort);
+  }
+  else  // Use saturation limits
+  {
+    ROS_DEBUG_STREAM_NAMED(name_, "Using saturation limits (not soft limits)");
+
+    const joint_limits_interface::PositionJointSaturationHandle sat_handle_position(joint_handle_position,
+                                                                                    joint_limits);
+    pos_jnt_sat_interface_.registerHandle(sat_handle_position);
+
+    const joint_limits_interface::VelocityJointSaturationHandle sat_handle_velocity(joint_handle_velocity,
+                                                                                    joint_limits);
+    vel_jnt_sat_interface_.registerHandle(sat_handle_velocity);
+
+    const joint_limits_interface::EffortJointSaturationHandle sat_handle_effort(joint_handle_effort, joint_limits);
+    eff_jnt_sat_interface_.registerHandle(sat_handle_effort);
+  }
+}
+
+void CombinableGenericHWInterface::reset()
+{
+  // Reset joint limits state, in case of mode switch or e-stop
+  pos_jnt_sat_interface_.reset();
+  pos_jnt_soft_limits_.reset();
+}
+
+void CombinableGenericHWInterface::printState()
+{
+  // WARNING: THIS IS NOT REALTIME SAFE
+  // FOR DEBUGGING ONLY, USE AT YOUR OWN ROBOT's RISK!
+  ROS_INFO_STREAM_THROTTLE(1, std::endl << printStateHelper());
+}
+
+std::string CombinableGenericHWInterface::printStateHelper()
+{
+  std::stringstream ss;
+  std::cout.precision(15);
+
+  for (std::size_t i = 0; i < num_joints_; ++i)
+  {
+    ss << "j" << i << ": " << std::fixed << joint_position_[i] << "\t ";
+    ss << std::fixed << joint_velocity_[i] << "\t ";
+    ss << std::fixed << joint_effort_[i] << std::endl;
+  }
+  return ss.str();
+}
+
+std::string CombinableGenericHWInterface::printCommandHelper()
+{
+  std::stringstream ss;
+  std::cout.precision(15);
+  ss << "    position     velocity         effort  \n";
+  for (std::size_t i = 0; i < num_joints_; ++i)
+  {
+    ss << "j" << i << ": " << std::fixed << joint_position_command_[i] << "\t ";
+    ss << std::fixed << joint_velocity_command_[i] << "\t ";
+    ss << std::fixed << joint_effort_command_[i] << std::endl;
+  }
+  return ss.str();
+}
+
+void CombinableGenericHWInterface::loadURDF(const ros::NodeHandle& nh, std::string param_name)
+{
+  std::string urdf_string;
+  urdf_model_ = new urdf::Model();
+
+  // search and wait for robot_description on param server
+  while (urdf_string.empty() && ros::ok())
+  {
+    std::string search_param_name;
+    if (nh.searchParam(param_name, search_param_name))
+    {
+      ROS_INFO_STREAM_NAMED(name_, "Waiting for model URDF on the ROS param server at location: " << nh.getNamespace()
+                                                                                                  << search_param_name);
+      nh.getParam(search_param_name, urdf_string);
+    }
+    else
+    {
+      ROS_INFO_STREAM_NAMED(name_, "Waiting for model URDF on the ROS param server at location: " << nh.getNamespace()
+                                                                                                  << param_name);
+      nh.getParam(param_name, urdf_string);
+    }
+
+    usleep(100000);
+  }
+
+  if (!urdf_model_->initString(urdf_string))
+    ROS_ERROR_STREAM_NAMED(name_, "Unable to load URDF model");
+  else
+    ROS_DEBUG_STREAM_NAMED(name_, "Received URDF from param server");
+}
+
+}  // namespace ros_control_boilerplate


### PR DESCRIPTION
First of all thanks for this library, it really helped setting up my custom gripper.
After a while I figured out that I need to use the `combined_robot_hw::CombinedRobotHW` if I want to pair my gripper with my robot arm.
However, the current implementation of the `ros_control_boilerplate::GenericHWInterface` is not compatible with it:

- the constructor is not parameterless (required for pluginlib)
- `init` on the other does not have the required NodeHandle parameters of `hardware_interface::RobotHW`
- `read` and `write` are fine since the original `hardware_interface::RobotHW` signature calls the simplified versions

Modifying the original `ros_control_boilerplate::GenericHWInterface` will certainly break the old API.
Thus, I have written a separate `CombinableGenericHWInterface` (is `GenericCombinableHWInterface`better?) and opened this pull request.
A few things bother me which I would like to discuss:

1. Currently we loose the support, to load an URDF from another location than the `robot_description` parameter. Of course, a subclass could inject a custom URDF in its constructor and `CombinableGenericHWInterface::init` could check if it is available. However, this behaviour is a hidden side effect. An alternative is to create a new `loadURDF` method.
2. Most of the code is copy paste with the major difference of doing most of the work from the constructor in `init`. We could either use the `CombinableGenericHWInterface` as base and subclass the `GenericHWInterface` from it in an adapter pattern fashion. Alternatively, we could move the functions into some utility header in a more functional fashion. This would require a lot of work, since the methods currently modify a lot of member variables.
3. I did not really get why the `root_nh` and the `robot_hw_nh` are required in the `RobotHW`. But, loading the joint names from the parameter server via the namespaced NodeHandle and a hardcoded string feels hacky. In my code I have tried to improve the TODO of @davetcoleman a bit but it still does not feel right since it depends on `name_ ` which has to be loaded in the constructor of the subclass. This is pretty much the same problem as loading the URDF in 1.

I'm looking forward to your feedback!
