### PR TITLE
Noetic devel update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ cache: ccache
 
 env:
   matrix:
-    - ROS_DISTRO=melodic
-    
+    - ROS_DISTRO=noetic
+
 before_script:
     - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Simple simulation interface and template for setting up a hardware interface for
 
 This open source project was developed at [PickNik Robotics](https://picknik.ai/). Need professional ROS development and consulting? Contact us at projects@picknik.ai for a free consultation.
 
+## Maintainers
+
+Special thanks to the following maintainers of this repo:
+
+ - Dave Coleman (@davetcoleman)
+ - Andy Zelenak (@AndyZe)
+ - John Morris (@zultron)
+
 ## Status:
 
  * [![Build Status](https://travis-ci.org/PickNikRobotics/ros_control_boilerplate.svg?branch=melodic-devel)](https://travis-ci.org/PickNikRobotics/ros_control_boilerplate) Travis CI

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Special thanks to the following maintainers of this repo:
  - Dave Coleman (@davetcoleman)
  - Andy Zelenak (@AndyZe)
  - John Morris (@zultron)
+ - Robert Wilbrandt (@RobertWilbrandt)
 
 ## Status:
 

--- a/include/ros_control_boilerplate/generic_hw_control_loop.h
+++ b/include/ros_control_boilerplate/generic_hw_control_loop.h
@@ -63,7 +63,7 @@ public:
    */
   GenericHWControlLoop(
       ros::NodeHandle& nh,
-      boost::shared_ptr<hardware_interface::RobotHW> hardware_interface);
+      std::shared_ptr<hardware_interface::RobotHW> hardware_interface);
 
   // Run the control loop (blocking)
   void run();
@@ -95,10 +95,10 @@ protected:
    * stopping ros_control-based controllers. It also serializes execution of all
    * running controllers in \ref update.
    */
-  boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
+  std::shared_ptr<controller_manager::ControllerManager> controller_manager_;
 
   /** \brief Abstract Hardware Interface for your robot */
-  boost::shared_ptr<hardware_interface::RobotHW> hardware_interface_;
+  std::shared_ptr<hardware_interface::RobotHW> hardware_interface_;
 
 };  // end class
 

--- a/include/ros_control_boilerplate/generic_hw_interface.h
+++ b/include/ros_control_boilerplate/generic_hw_interface.h
@@ -69,7 +69,7 @@ public:
    * \param nh - Node handle for topics.
    * \param urdf - optional pointer to a parsed robot model
    */
-  GenericHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model = NULL);
+  GenericHWInterface(const ros::NodeHandle &nh, urdf::Model *urdf_model = NULL);
 
   /** \brief Destructor */
   virtual ~GenericHWInterface() {}
@@ -158,7 +158,7 @@ public:
 protected:
 
   /** \brief Get the URDF XML from the parameter server */
-  virtual void loadURDF(ros::NodeHandle& nh, std::string param_name);
+  virtual void loadURDF(const ros::NodeHandle& nh, std::string param_name);
 
   // Short name of this class
   std::string name_;

--- a/include/ros_control_boilerplate/generic_hw_interface.h
+++ b/include/ros_control_boilerplate/generic_hw_interface.h
@@ -40,9 +40,6 @@
 #ifndef GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H
 #define GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H
 
-// C++
-#include <boost/scoped_ptr.hpp>
-
 // ROS
 #include <ros/ros.h>
 #include <urdf/model.h>

--- a/include/ros_control_boilerplate/tools/controller_to_csv.h
+++ b/include/ros_control_boilerplate/tools/controller_to_csv.h
@@ -112,9 +112,9 @@ private:
 
 };  // end class
 
-// Create boost pointers for this class
-typedef boost::shared_ptr<ControllerToCSV> ControllerToCSVPtr;
-typedef boost::shared_ptr<const ControllerToCSV> ControllerToCSVConstPtr;
+// Create std pointers for this class
+typedef std::shared_ptr<ControllerToCSV> ControllerToCSVPtr;
+typedef std::shared_ptr<const ControllerToCSV> ControllerToCSVConstPtr;
 
 }  // end namespace
 

--- a/rrbot_control/launch/rrbot_hardware.launch
+++ b/rrbot_control/launch/rrbot_hardware.launch
@@ -7,7 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <!-- Load example URDF -->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find rrbot_description)/urdf/rrbot.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find rrbot_description)/urdf/rrbot.xacro'" />
 
   <group ns="rrbot">
 

--- a/rrbot_control/launch/rrbot_simulation.launch
+++ b/rrbot_control/launch/rrbot_simulation.launch
@@ -7,7 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <!-- Load example URDF -->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find rrbot_description)/urdf/rrbot.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find rrbot_description)/urdf/rrbot.xacro'" />
 
   <group ns="rrbot">
 

--- a/rrbot_control/launch/rrbot_test_trajectory.launch
+++ b/rrbot_control/launch/rrbot_test_trajectory.launch
@@ -11,7 +11,7 @@
     <!-- Load hardware interface -->
     <node name="test_trajectory" pkg="ros_control_boilerplate" type="test_trajectory"
           output="screen" launch-prefix="$(arg launch_prefix)">
-      <param name="action_topic" value="/rrbot/position_trajectory_controller/follow_joint_trajectory/"/>
+      <param name="trajectory_controller" value="position_trajectory_controller"/>
       <rosparam file="$(find ros_control_boilerplate)/rrbot_control/config/rrbot_controllers.yaml" command="load"/>
     </node>
 

--- a/rrbot_control/launch/rrbot_visualize.launch
+++ b/rrbot_control/launch/rrbot_visualize.launch
@@ -2,7 +2,7 @@
 <launch>
 
   <!-- Load example URDF -->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find rrbot_description)/urdf/rrbot.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro '$(find rrbot_description)/urdf/rrbot.xacro'" />
     
   <!-- Show in Rviz  -->
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find rrbot_description)/launch/rrbot.rviz"/>

--- a/rrbot_control/src/rrbot_hw_main.cpp
+++ b/rrbot_control/src/rrbot_hw_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
 
   // NOTE: We run the ROS loop in a separate thread as external calls such
   // as service callbacks to load controllers can block the (main) control loop
-  ros::AsyncSpinner spinner(2);
+  ros::AsyncSpinner spinner(3);
   spinner.start();
 
   // Create the hardware interface specific to your robot

--- a/rrbot_control/src/rrbot_hw_main.cpp
+++ b/rrbot_control/src/rrbot_hw_main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
   spinner.start();
 
   // Create the hardware interface specific to your robot
-  boost::shared_ptr<rrbot_control::RRBotHWInterface> rrbot_hw_interface
+  std::shared_ptr<rrbot_control::RRBotHWInterface> rrbot_hw_interface
     (new rrbot_control::RRBotHWInterface(nh));
   rrbot_hw_interface->init();
 

--- a/src/generic_hw_control_loop.cpp
+++ b/src/generic_hw_control_loop.cpp
@@ -45,7 +45,7 @@
 namespace ros_control_boilerplate
 {
 GenericHWControlLoop::GenericHWControlLoop(
-    ros::NodeHandle& nh, boost::shared_ptr<hardware_interface::RobotHW> hardware_interface)
+    ros::NodeHandle& nh, std::shared_ptr<hardware_interface::RobotHW> hardware_interface)
   : nh_(nh), hardware_interface_(hardware_interface)
 {
   // Create the controller manager

--- a/src/generic_hw_interface.cpp
+++ b/src/generic_hw_interface.cpp
@@ -44,7 +44,7 @@
 
 namespace ros_control_boilerplate
 {
-GenericHWInterface::GenericHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model)
+GenericHWInterface::GenericHWInterface(const ros::NodeHandle &nh, urdf::Model *urdf_model)
   : name_("generic_hw_interface")
   , nh_(nh)
   , use_rosparam_joint_limits_(false)
@@ -301,7 +301,7 @@ std::string GenericHWInterface::printCommandHelper()
   return ss.str();
 }
 
-void GenericHWInterface::loadURDF(ros::NodeHandle &nh, std::string param_name)
+void GenericHWInterface::loadURDF(const ros::NodeHandle &nh, std::string param_name)
 {
   std::string urdf_string;
   urdf_model_ = new urdf::Model();

--- a/src/sim_hw_main.cpp
+++ b/src/sim_hw_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
 
   // NOTE: We run the ROS loop in a separate thread as external calls such
   // as service callbacks to load controllers can block the (main) control loop
-  ros::AsyncSpinner spinner(2);
+  ros::AsyncSpinner spinner(3);
   spinner.start();
 
   // Create the hardware interface specific to your robot

--- a/src/sim_hw_main.cpp
+++ b/src/sim_hw_main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
   spinner.start();
 
   // Create the hardware interface specific to your robot
-  boost::shared_ptr<ros_control_boilerplate::SimHWInterface> sim_hw_interface
+  std::shared_ptr<ros_control_boilerplate::SimHWInterface> sim_hw_interface
     (new ros_control_boilerplate::SimHWInterface(nh));
   sim_hw_interface->init();
 

--- a/src/tools/test_trajectory.cpp
+++ b/src/tools/test_trajectory.cpp
@@ -57,21 +57,21 @@ public:
   TestTrajectory()
     : nh_private_("~")
   {
-    std::string action_topic;
-    nh_private_.getParam("action_topic", action_topic);
-    if (action_topic.empty())
+    nh_private_.getParam("trajectory_controller", trajectory_controller);
+    if (trajectory_controller.empty())
     {
       ROS_FATAL_STREAM_NAMED(
           "test_trajectory",
-          "Not follow joint trajectory action topic found on the parameter server");
+          "No joint trajectory controller parameter found on the parameter server");
       exit(-1);
     }
-    ROS_INFO_STREAM_NAMED("test_trajectory", "Connecting to action " << action_topic);
+    ROS_INFO_STREAM_NAMED("test_trajectory",
+                          "Connecting to controller " << trajectory_controller);
 
     // create the action client
     // true causes the client to spin its own thread
     actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> action_client(
-        action_topic, true);
+      trajectory_controller + "/follow_joint_trajectory/", true);
 
     ROS_INFO_NAMED("test_trajetory", "Waiting for action server to start.");
     // wait for the action server to start
@@ -111,7 +111,7 @@ public:
     double max_joint_value = 3.14;
 
     // Get joint names
-    nh_private_.getParam("hardware_interface/joints", joint_names);
+    nh_private_.getParam(trajectory_controller + "/joints", joint_names);
     if (joint_names.size() == 0)
     {
       ROS_FATAL_STREAM_NAMED(
@@ -157,6 +157,10 @@ public:
 private:
   // A shared node handle
   ros::NodeHandle nh_private_;
+
+  // A string containing the 'trajectory_controller' parameter value
+  std::string trajectory_controller;
+
 
 };  // end class
 

--- a/src/tools/test_trajectory.cpp
+++ b/src/tools/test_trajectory.cpp
@@ -162,9 +162,9 @@ private:
   std::string trajectory_controller;
 };  // end class
 
-// Create boost pointers for this class
-typedef boost::shared_ptr<TestTrajectory> TestTrajectoryPtr;
-typedef boost::shared_ptr<const TestTrajectory> TestTrajectoryConstPtr;
+// Create std pointers for this class
+typedef std::shared_ptr<TestTrajectory> TestTrajectoryPtr;
+typedef std::shared_ptr<const TestTrajectory> TestTrajectoryConstPtr;
 
 }  // end namespace
 

--- a/src/tools/test_trajectory.cpp
+++ b/src/tools/test_trajectory.cpp
@@ -160,8 +160,6 @@ private:
 
   // A string containing the 'trajectory_controller' parameter value
   std::string trajectory_controller;
-
-
 };  // end class
 
 // Create boost pointers for this class


### PR DESCRIPTION
Our ```noetic-devel``` branch seems to have lagged behind the ```melodic-devel``` branch. This PR should address this by doing two things:
- Rebase the recent ```melodic-devel``` commits to ```noetic-devel``` (including branching history as possible), as they are useful no matter which ROS version
- Do small cleanup for noetic transition: Set CI version to noetic and use ```xacro``` instead of ```xacro.py```

It might make sense to change the default branch to ```noetic-devel``` too (just as ```ros_control``` did). @davetcoleman @AndyZe @zultron i don't think i have the permissions to do this, can somebody do it?