### PR TITLE
Code formatting & linting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,75 @@
+---
+BasedOnStyle:  Google
+ColumnLimit:    120
+MaxEmptyLinesToKeep: 1
+SortIncludes: false
+
+Standard:        Auto
+IndentWidth:     2
+TabWidth:        2
+UseTab:          Never
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+NamespaceIndentation: None
+ContinuationIndentWidth: 4
+IndentCaseLabels: true
+IndentFunctionDeclarationAfterType: false
+
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+ExperimentalAutoDetectBinPacking: false
+ObjCSpaceBeforeProtocolList: true
+Cpp11BracedListStyle: false
+
+AllowShortBlocksOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortCaseLabelsOnASingleLine: false
+
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+
+BinPackParameters: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: false
+PointerBindsToType: true
+
+PenaltyExcessCharacter: 50
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 1000
+PenaltyBreakFirstLessLess: 10
+PenaltyBreakString: 100
+PenaltyReturnTypeOnItsOwnLine: 50
+
+SpacesBeforeTrailingComments: 2
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping:
+    AfterCaseLabel: true
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ cache: ccache
 env:
   matrix:
     - ROS_DISTRO=melodic
-    
+    - ROS_DISTRO=melodic TEST="clang-format catkin_lint"
+
 before_script:
     - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,47 +2,49 @@ cmake_minimum_required(VERSION 2.8.3)
 project(ros_control_boilerplate)
 
 # C++ 11
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall ${CMAKE_CXX_FLAGS}")
+if(NOT "${CMAKE_CXX_STANDARD}")
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(catkin REQUIRED COMPONENTS
-  cmake_modules
-  hardware_interface
-  controller_manager
-  roscpp
-  control_msgs
-  trajectory_msgs
   actionlib
-  urdf
-  joint_limits_interface
-  transmission_interface
+  cmake_modules
+  control_msgs
   control_toolbox
-  std_msgs
-  sensor_msgs
+  controller_manager
+  hardware_interface
+  joint_limits_interface
+  roscpp
   rosparam_shortcuts
+  sensor_msgs
+  std_msgs
+  trajectory_msgs
+  transmission_interface
+  urdf
 )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Gflags REQUIRED)
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
 catkin_package(
   INCLUDE_DIRS
     include
   CATKIN_DEPENDS
-    hardware_interface
-    controller_manager
-    roscpp
+    actionlib
     control_msgs
-    trajectory_msgs
-    urdf
-    joint_limits_interface
-    transmission_interface
     control_toolbox
-    std_msgs
-    sensor_msgs
+    controller_manager
+    hardware_interface
+    joint_limits_interface
+    roscpp
     rosparam_shortcuts
+    sensor_msgs
+    std_msgs
+    trajectory_msgs
+    transmission_interface
+    urdf
   LIBRARIES
     generic_hw_control_loop
     generic_hw_interface
@@ -60,7 +62,9 @@ include_directories(
 )
 
 # Control loop
-add_library(generic_hw_control_loop src/generic_hw_control_loop.cpp)
+add_library(generic_hw_control_loop
+  src/generic_hw_control_loop.cpp
+)
 target_link_libraries(generic_hw_control_loop
   ${catkin_LIBRARIES}
 )
@@ -139,22 +143,22 @@ add_subdirectory(rrbot_control)
 
 # Install libraries
 install(TARGETS
+    controller_to_csv
+    csv_to_controller
     generic_hw_control_loop
     generic_hw_interface
     sim_hw_interface
-    controller_to_csv
-    csv_to_controller
   LIBRARY DESTINATION
     ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 
 # Install executables
 install(TARGETS
-    ${PROJECT_NAME}_sim_hw_main
-    ${PROJECT_NAME}_test_trajectory
     ${PROJECT_NAME}_controller_to_csv_main
     ${PROJECT_NAME}_csv_to_controller_main
     ${PROJECT_NAME}_keyboard_teleop
+    ${PROJECT_NAME}_sim_hw_main
+    ${PROJECT_NAME}_test_trajectory
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/include/ros_control_boilerplate/generic_hw_control_loop.h
+++ b/include/ros_control_boilerplate/generic_hw_control_loop.h
@@ -61,15 +61,12 @@ public:
    * \param NodeHandle
    * \param hardware_interface - the robot-specific hardware interface to be use with your robot
    */
-  GenericHWControlLoop(
-      ros::NodeHandle& nh,
-      boost::shared_ptr<hardware_interface::RobotHW> hardware_interface);
+  GenericHWControlLoop(ros::NodeHandle& nh, boost::shared_ptr<hardware_interface::RobotHW> hardware_interface);
 
   // Run the control loop (blocking)
   void run();
 
 protected:
-
   // Update funcion called with loop_hz_ rate
   void update();
 
@@ -102,4 +99,4 @@ protected:
 
 };  // end class
 
-}  // namespace
+}  // namespace ros_control_boilerplate

--- a/include/ros_control_boilerplate/generic_hw_interface.h
+++ b/include/ros_control_boilerplate/generic_hw_interface.h
@@ -59,7 +59,6 @@
 
 namespace ros_control_boilerplate
 {
-
 /// \brief Hardware interface for a robot
 class GenericHWInterface : public hardware_interface::RobotHW
 {
@@ -69,16 +68,18 @@ public:
    * \param nh - Node handle for topics.
    * \param urdf - optional pointer to a parsed robot model
    */
-  GenericHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model = NULL);
+  GenericHWInterface(ros::NodeHandle& nh, urdf::Model* urdf_model = NULL);
 
   /** \brief Destructor */
-  virtual ~GenericHWInterface() {}
+  virtual ~GenericHWInterface()
+  {
+  }
 
   /** \brief Initialize the hardware interface */
   virtual void init();
 
   /** \brief Read the state from the robot hardware. */
-  virtual void read(ros::Duration &elapsed_time) = 0;
+  virtual void read(ros::Duration& elapsed_time) = 0;
 
   /** \brief Read the state from the robot hardware
    *
@@ -94,7 +95,7 @@ public:
   }
 
   /** \brief Write the command to the robot hardware. */
-  virtual void write(ros::Duration &elapsed_time) = 0;
+  virtual void write(ros::Duration& elapsed_time) = 0;
 
   /** \brief Write the command to the robot hardware
    *
@@ -118,8 +119,8 @@ public:
    * with regard to necessary hardware interface switches. Start and stop list are disjoint.
    * This is just a check, the actual switch is done in doSwitch()
    */
-  virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo> &start_list,
-                         const std::list<hardware_interface::ControllerInfo> &stop_list) const
+  virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                         const std::list<hardware_interface::ControllerInfo>& stop_list) const
   {
     return true;
   }
@@ -129,8 +130,8 @@ public:
    * and stop the given controllers.
    * Start and stop list are disjoint. The feasability was checked in canSwitch() beforehand.
    */
-  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list,
-                        const std::list<hardware_interface::ControllerInfo> &stop_list)
+  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                        const std::list<hardware_interface::ControllerInfo>& stop_list)
   {
   }
 
@@ -140,13 +141,12 @@ public:
    *
    * \return the joint's type, lower position limit, upper position limit, and effort limit.
    */
-  virtual void registerJointLimits(const hardware_interface::JointHandle &joint_handle_position,
-                           const hardware_interface::JointHandle &joint_handle_velocity,
-                           const hardware_interface::JointHandle &joint_handle_effort,
-                           std::size_t joint_id);
+  virtual void registerJointLimits(const hardware_interface::JointHandle& joint_handle_position,
+                                   const hardware_interface::JointHandle& joint_handle_velocity,
+                                   const hardware_interface::JointHandle& joint_handle_effort, std::size_t joint_id);
 
   /** \breif Enforce limits for all values before writing */
-  virtual void enforceLimits(ros::Duration &period) = 0;
+  virtual void enforceLimits(ros::Duration& period) = 0;
 
   /** \brief Helper for debugging a joint's state */
   virtual void printState();
@@ -156,7 +156,6 @@ public:
   std::string printCommandHelper();
 
 protected:
-
   /** \brief Get the URDF XML from the parameter server */
   virtual void loadURDF(ros::NodeHandle& nh, std::string param_name);
 
@@ -185,7 +184,7 @@ protected:
   // Configuration
   std::vector<std::string> joint_names_;
   std::size_t num_joints_;
-  urdf::Model *urdf_model_;
+  urdf::Model* urdf_model_;
 
   // Modes
   bool use_rosparam_joint_limits_;
@@ -209,6 +208,6 @@ protected:
 
 };  // class
 
-}  // namespace
+}  // namespace ros_control_boilerplate
 
-#endif // GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H
+#endif  // GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H

--- a/include/ros_control_boilerplate/sim_hw_interface.h
+++ b/include/ros_control_boilerplate/sim_hw_interface.h
@@ -44,7 +44,6 @@
 
 namespace ros_control_boilerplate
 {
-
 /** \brief Hardware interface for a robot */
 class SimHWInterface : public GenericHWInterface
 {
@@ -59,18 +58,17 @@ public:
   virtual void init();
 
   /** \brief Read the state from the robot hardware. */
-  virtual void read(ros::Duration &elapsed_time);
+  virtual void read(ros::Duration& elapsed_time);
 
   /** \brief Write the command to the robot hardware. */
-  virtual void write(ros::Duration &elapsed_time);
+  virtual void write(ros::Duration& elapsed_time);
 
   /** \breif Enforce limits for all values before writing */
-  virtual void enforceLimits(ros::Duration &period);
+  virtual void enforceLimits(ros::Duration& period);
 
 protected:
-
   /** \brief Basic model of system for position control */
-  virtual void positionControlSimulation(ros::Duration &elapsed_time, const std::size_t joint_id);
+  virtual void positionControlSimulation(ros::Duration& elapsed_time, const std::size_t joint_id);
 
   // Name of this class
   std::string name_;
@@ -87,6 +85,6 @@ protected:
 
 };  // class
 
-}  // namespace
+}  // namespace ros_control_boilerplate
 
 #endif

--- a/include/ros_control_boilerplate/tools/controller_to_csv.h
+++ b/include/ros_control_boilerplate/tools/controller_to_csv.h
@@ -47,7 +47,6 @@
 
 namespace ros_control_boilerplate
 {
-
 class ControllerToCSV
 {
 public:
@@ -70,7 +69,6 @@ public:
   void stopRecording();
 
 private:
-
   /** \brief Send all resulting data to file */
   bool writeToFile();
 
@@ -81,7 +79,7 @@ private:
   void update(const ros::TimerEvent& e);
 
   /** \brief Check if topic has been connected to successfully */
-  bool waitForSubscriber(const ros::Subscriber &sub, const double &wait_time = 10.0);
+  bool waitForSubscriber(const ros::Subscriber& sub, const double& wait_time = 10.0);
 
   // Class name
   std::string name_ = "controller_to_csv";
@@ -95,7 +93,7 @@ private:
 
   // Listener to state of controller
   ros::Subscriber state_sub_;
-  double record_hz_; // how often to record the latest incoming data. if zero, record all
+  double record_hz_;  // how often to record the latest incoming data. if zero, record all
 
   // Where to save the CSV
   std::string file_name_;
@@ -116,6 +114,6 @@ private:
 typedef boost::shared_ptr<ControllerToCSV> ControllerToCSVPtr;
 typedef boost::shared_ptr<const ControllerToCSV> ControllerToCSVConstPtr;
 
-}  // end namespace
+}  // namespace ros_control_boilerplate
 
 #endif

--- a/include/ros_control_boilerplate/tools/csv_to_controller.h
+++ b/include/ros_control_boilerplate/tools/csv_to_controller.h
@@ -60,13 +60,12 @@ public:
   /**
    * \brief Constructor
    */
-  CSVToController(const std::string& joint_trajectory_action,
-                  const std::string& controller_state_topic);
+  CSVToController(const std::string& joint_trajectory_action, const std::string& controller_state_topic);
 
   /** \brief Callback from ROS message */
   void stateCB(const control_msgs::JointTrajectoryControllerState::ConstPtr& state);
 
-  void printPoint(trajectory_msgs::JointTrajectoryPoint &point);
+  void printPoint(trajectory_msgs::JointTrajectoryPoint& point);
 
   // Start the data collection
   void loadAndRunCSV(const std::string& file_name);
@@ -90,6 +89,6 @@ private:
 
 };  // end class
 
-}  // end namespace
+}  // namespace ros_control_boilerplate
 
 #endif

--- a/include/ros_control_boilerplate/tools/joystick_manual_control.h
+++ b/include/ros_control_boilerplate/tools/joystick_manual_control.h
@@ -59,17 +59,14 @@ public:
    * "/"
    */
   JoystickManualControl(const std::string& parent_name, const std::string& service_namespace)
-    : parent_name_(parent_name)
-    , using_trajectory_controller_(true)
+    : parent_name_(parent_name), using_trajectory_controller_(true)
   {
     switch_service_ = service_namespace + "/controller_manager/switch_controller";
     load_service_ = service_namespace + "/controller_manager/load_controller";
 
     // Switch modes of controllers
-    switch_controlers_client_ =
-        nh_.serviceClient<controller_manager_msgs::SwitchController>(switch_service_);
-    load_controlers_client_ =
-        nh_.serviceClient<controller_manager_msgs::LoadController>(load_service_);
+    switch_controlers_client_ = nh_.serviceClient<controller_manager_msgs::SwitchController>(switch_service_);
+    load_controlers_client_ = nh_.serviceClient<controller_manager_msgs::LoadController>(load_service_);
 
     // Subscribe to joystick control
     std::size_t queue_size = 1;
@@ -105,9 +102,8 @@ public:
       while (!load_controlers_client_.call(service) && ros::ok())
       {
         if (counter > 100)
-          ROS_WARN_STREAM_THROTTLE_NAMED(1.0, parent_name_, "Failed to load controller '"
-                                                                << manual_controllers_[i]
-                                                                << "', trying again");
+          ROS_WARN_STREAM_THROTTLE_NAMED(1.0, parent_name_,
+                                         "Failed to load controller '" << manual_controllers_[i] << "', trying again");
         ros::spinOnce();
         ros::Duration(0.1).sleep();
         counter++;
@@ -190,6 +186,6 @@ protected:
 
 };  // end class
 
-}  // end namespace
+}  // namespace ros_control_boilerplate
 
 #endif

--- a/package.xml
+++ b/package.xml
@@ -46,6 +46,12 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>rosparam_shortcuts</run_depend>
 
+  <!-- These are needed if you want to run the rrbot simulation demo -->
+  <!--<run_depend>xacro</run_depend>-->
+  <!--<run_depend>robot_state_publisher</run_depend>-->
+  <!--<run_depend>rrbot_description</run_depend>-->
+  <!--<run_depend>rviz</run_depend>-->
+
   <export>
   </export>
 </package>

--- a/rrbot_control/include/rrbot_control/rrbot_hw_interface.h
+++ b/rrbot_control/include/rrbot_control/rrbot_hw_interface.h
@@ -44,7 +44,6 @@
 
 namespace rrbot_control
 {
-
 /// \brief Hardware interface for a robot
 class RRBotHWInterface : public ros_control_boilerplate::GenericHWInterface
 {
@@ -56,16 +55,16 @@ public:
   RRBotHWInterface(ros::NodeHandle& nh, urdf::Model* urdf_model = NULL);
 
   /** \brief Read the state from the robot hardware. */
-  virtual void read(ros::Duration &elapsed_time);
+  virtual void read(ros::Duration& elapsed_time);
 
   /** \brief Write the command to the robot hardware. */
-  virtual void write(ros::Duration &elapsed_time);
+  virtual void write(ros::Duration& elapsed_time);
 
   /** \breif Enforce limits for all values before writing */
-  virtual void enforceLimits(ros::Duration &period);
+  virtual void enforceLimits(ros::Duration& period);
 
 };  // class
 
-}  // namespace
+}  // namespace rrbot_control
 
 #endif

--- a/rrbot_control/src/rrbot_hw_interface.cpp
+++ b/rrbot_control/src/rrbot_hw_interface.cpp
@@ -41,14 +41,13 @@
 
 namespace rrbot_control
 {
-
-RRBotHWInterface::RRBotHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model)
+RRBotHWInterface::RRBotHWInterface(ros::NodeHandle& nh, urdf::Model* urdf_model)
   : ros_control_boilerplate::GenericHWInterface(nh, urdf_model)
 {
   ROS_INFO_NAMED("rrbot_hw_interface", "RRBotHWInterface Ready.");
 }
 
-void RRBotHWInterface::read(ros::Duration &elapsed_time)
+void RRBotHWInterface::read(ros::Duration& elapsed_time)
 {
   // ----------------------------------------------------
   // ----------------------------------------------------
@@ -61,7 +60,7 @@ void RRBotHWInterface::read(ros::Duration &elapsed_time)
   // ----------------------------------------------------
 }
 
-void RRBotHWInterface::write(ros::Duration &elapsed_time)
+void RRBotHWInterface::write(ros::Duration& elapsed_time)
 {
   // Safety
   enforceLimits(elapsed_time);
@@ -86,7 +85,7 @@ void RRBotHWInterface::write(ros::Duration &elapsed_time)
   // ----------------------------------------------------
 }
 
-void RRBotHWInterface::enforceLimits(ros::Duration &period)
+void RRBotHWInterface::enforceLimits(ros::Duration& period)
 {
   // ----------------------------------------------------
   // ----------------------------------------------------
@@ -120,4 +119,4 @@ void RRBotHWInterface::enforceLimits(ros::Duration &period)
   // ----------------------------------------------------
 }
 
-}  // namespace
+}  // namespace rrbot_control

--- a/rrbot_control/src/rrbot_hw_main.cpp
+++ b/rrbot_control/src/rrbot_hw_main.cpp
@@ -50,13 +50,12 @@ int main(int argc, char** argv)
   spinner.start();
 
   // Create the hardware interface specific to your robot
-  boost::shared_ptr<rrbot_control::RRBotHWInterface> rrbot_hw_interface
-    (new rrbot_control::RRBotHWInterface(nh));
+  boost::shared_ptr<rrbot_control::RRBotHWInterface> rrbot_hw_interface(new rrbot_control::RRBotHWInterface(nh));
   rrbot_hw_interface->init();
 
   // Start the control loop
   ros_control_boilerplate::GenericHWControlLoop control_loop(nh, rrbot_hw_interface);
-  control_loop.run(); // Blocks until shutdown signal recieved
+  control_loop.run();  // Blocks until shutdown signal recieved
 
   return 0;
 }

--- a/src/generic_hw_control_loop.cpp
+++ b/src/generic_hw_control_loop.cpp
@@ -33,8 +33,8 @@
  *********************************************************************/
 
 /* Author: Dave Coleman
-   Desc:   Example control loop for reading, updating, and writing commands to a hardware interface
-   using MONOTOIC system time
+   Desc:   Example control loop for reading, updating, and writing commands to a
+   hardware interface using MONOTOIC system time
 */
 
 #include <ros_control_boilerplate/generic_hw_control_loop.h>
@@ -44,8 +44,8 @@
 
 namespace ros_control_boilerplate
 {
-GenericHWControlLoop::GenericHWControlLoop(
-    ros::NodeHandle& nh, boost::shared_ptr<hardware_interface::RobotHW> hardware_interface)
+GenericHWControlLoop::GenericHWControlLoop(ros::NodeHandle& nh,
+                                           boost::shared_ptr<hardware_interface::RobotHW> hardware_interface)
   : nh_(nh), hardware_interface_(hardware_interface)
 {
   // Create the controller manager
@@ -67,7 +67,8 @@ GenericHWControlLoop::GenericHWControlLoop(
 void GenericHWControlLoop::run()
 {
   ros::Rate rate(loop_hz_);
-  while(ros::ok()) {
+  while (ros::ok())
+  {
     update();
     rate.sleep();
   }
@@ -81,8 +82,8 @@ void GenericHWControlLoop::update()
       ros::Duration(current_time_.tv_sec - last_time_.tv_sec + (current_time_.tv_nsec - last_time_.tv_nsec) / BILLION);
   last_time_ = current_time_;
   ros::Time now = ros::Time::now();
-  // ROS_DEBUG_STREAM_THROTTLE_NAMED(1, "generic_hw_main","Sampled update loop with elapsed
-  // time " << elapsed_time_.toSec());
+  // ROS_DEBUG_STREAM_THROTTLE_NAMED(1, "generic_hw_main","Sampled update loop
+  // with elapsed time " << elapsed_time_.toSec());
 
   // Error check cycle time
   const double cycle_time_error = (elapsed_time_ - desired_update_period_).toSec();
@@ -103,4 +104,4 @@ void GenericHWControlLoop::update()
   hardware_interface_->write(now, elapsed_time_);
 }
 
-}  // namespace
+}  // namespace ros_control_boilerplate

--- a/src/generic_hw_interface.cpp
+++ b/src/generic_hw_interface.cpp
@@ -44,11 +44,8 @@
 
 namespace ros_control_boilerplate
 {
-GenericHWInterface::GenericHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model)
-  : name_("generic_hw_interface")
-  , nh_(nh)
-  , use_rosparam_joint_limits_(false)
-  , use_soft_limits_if_available_(false)
+GenericHWInterface::GenericHWInterface(ros::NodeHandle& nh, urdf::Model* urdf_model)
+  : name_("generic_hw_interface"), nh_(nh), use_rosparam_joint_limits_(false), use_soft_limits_if_available_(false)
 {
   // Check if the URDF model needs to be loaded
   if (urdf_model == NULL)
@@ -57,7 +54,8 @@ GenericHWInterface::GenericHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_mo
     urdf_model_ = urdf_model;
 
   // Load rosparams
-  ros::NodeHandle rpnh(nh_, "hardware_interface"); // TODO(davetcoleman): change the namespace to "generic_hw_interface" aka name_
+  ros::NodeHandle rpnh(
+      nh_, "hardware_interface");  // TODO(davetcoleman): change the namespace to "generic_hw_interface" aka name_
   std::size_t error = 0;
   error += !rosparam_shortcuts::get(name_, rpnh, "joints", joint_names_);
   rosparam_shortcuts::shutdownIfError(name_, error);
@@ -118,9 +116,9 @@ void GenericHWInterface::init()
   ROS_INFO_STREAM_NAMED(name_, "GenericHWInterface Ready.");
 }
 
-void GenericHWInterface::registerJointLimits(const hardware_interface::JointHandle &joint_handle_position,
-                                             const hardware_interface::JointHandle &joint_handle_velocity,
-                                             const hardware_interface::JointHandle &joint_handle_effort,
+void GenericHWInterface::registerJointLimits(const hardware_interface::JointHandle& joint_handle_position,
+                                             const hardware_interface::JointHandle& joint_handle_velocity,
+                                             const hardware_interface::JointHandle& joint_handle_effort,
                                              std::size_t joint_id)
 {
   // Default values
@@ -157,17 +155,17 @@ void GenericHWInterface::registerJointLimits(const hardware_interface::JointHand
   {
     has_joint_limits = true;
     ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " has URDF position limits ["
-                                                            << joint_limits.min_position << ", "
-                                                            << joint_limits.max_position << "]");
+                                           << joint_limits.min_position << ", " << joint_limits.max_position << "]");
     if (joint_limits.has_velocity_limits)
       ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " has URDF velocity limit ["
-                                                              << joint_limits.max_velocity << "]");
+                                             << joint_limits.max_velocity << "]");
   }
   else
   {
     if (urdf_joint->type != urdf::Joint::CONTINUOUS)
-      ROS_WARN_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " does not have a URDF "
-                            "position limit");
+      ROS_WARN_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id]
+                                            << " does not have a URDF "
+                                               "position limit");
   }
 
   // Get limits from ROS param
@@ -176,13 +174,11 @@ void GenericHWInterface::registerJointLimits(const hardware_interface::JointHand
     if (joint_limits_interface::getJointLimits(joint_names_[joint_id], nh_, joint_limits))
     {
       has_joint_limits = true;
-      ROS_DEBUG_STREAM_NAMED(name_,
-                             "Joint " << joint_names_[joint_id] << " has rosparam position limits ["
-                                      << joint_limits.min_position << ", " << joint_limits.max_position << "]");
+      ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " has rosparam position limits ["
+                                             << joint_limits.min_position << ", " << joint_limits.max_position << "]");
       if (joint_limits.has_velocity_limits)
-        ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id]
-                                                                << " has rosparam velocity limit ["
-                                                                << joint_limits.max_velocity << "]");
+        ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " has rosparam velocity limit ["
+                                               << joint_limits.max_velocity << "]");
     }  // the else debug message provided internally by joint_limits_interface
   }
 
@@ -196,8 +192,9 @@ void GenericHWInterface::registerJointLimits(const hardware_interface::JointHand
     }
     else
     {
-      ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id] << " does not have soft joint "
-                             "limits");
+      ROS_DEBUG_STREAM_NAMED(name_, "Joint " << joint_names_[joint_id]
+                                             << " does not have soft joint "
+                                                "limits");
     }
   }
 
@@ -234,13 +231,13 @@ void GenericHWInterface::registerJointLimits(const hardware_interface::JointHand
   {
     ROS_DEBUG_STREAM_NAMED(name_, "Using soft saturation limits");
     const joint_limits_interface::PositionJointSoftLimitsHandle soft_handle_position(joint_handle_position,
-                                                                                       joint_limits, soft_limits);
+                                                                                     joint_limits, soft_limits);
     pos_jnt_soft_limits_.registerHandle(soft_handle_position);
     const joint_limits_interface::VelocityJointSoftLimitsHandle soft_handle_velocity(joint_handle_velocity,
-                                                                                       joint_limits, soft_limits);
+                                                                                     joint_limits, soft_limits);
     vel_jnt_soft_limits_.registerHandle(soft_handle_velocity);
     const joint_limits_interface::EffortJointSoftLimitsHandle soft_handle_effort(joint_handle_effort, joint_limits,
-                                                                                   soft_limits);
+                                                                                 soft_limits);
     eff_jnt_soft_limits_.registerHandle(soft_handle_effort);
   }
   else  // Use saturation limits
@@ -269,8 +266,7 @@ void GenericHWInterface::printState()
 {
   // WARNING: THIS IS NOT REALTIME SAFE
   // FOR DEBUGGING ONLY, USE AT YOUR OWN ROBOT's RISK!
-  ROS_INFO_STREAM_THROTTLE(1, std::endl
-                                  << printStateHelper());
+  ROS_INFO_STREAM_THROTTLE(1, std::endl << printStateHelper());
 }
 
 std::string GenericHWInterface::printStateHelper()
@@ -301,7 +297,7 @@ std::string GenericHWInterface::printCommandHelper()
   return ss.str();
 }
 
-void GenericHWInterface::loadURDF(ros::NodeHandle &nh, std::string param_name)
+void GenericHWInterface::loadURDF(ros::NodeHandle& nh, std::string param_name)
 {
   std::string urdf_string;
   urdf_model_ = new urdf::Model();
@@ -312,14 +308,14 @@ void GenericHWInterface::loadURDF(ros::NodeHandle &nh, std::string param_name)
     std::string search_param_name;
     if (nh.searchParam(param_name, search_param_name))
     {
-      ROS_INFO_STREAM_NAMED(name_, "Waiting for model URDF on the ROS param server at location: " <<
-                            nh.getNamespace() << search_param_name);
+      ROS_INFO_STREAM_NAMED(name_, "Waiting for model URDF on the ROS param server at location: " << nh.getNamespace()
+                                                                                                  << search_param_name);
       nh.getParam(search_param_name, urdf_string);
     }
     else
     {
-      ROS_INFO_STREAM_NAMED(name_, "Waiting for model URDF on the ROS param server at location: " <<
-                            nh.getNamespace() << param_name);
+      ROS_INFO_STREAM_NAMED(name_, "Waiting for model URDF on the ROS param server at location: " << nh.getNamespace()
+                                                                                                  << param_name);
       nh.getParam(param_name, urdf_string);
     }
 
@@ -332,4 +328,4 @@ void GenericHWInterface::loadURDF(ros::NodeHandle &nh, std::string param_name)
     ROS_DEBUG_STREAM_NAMED(name_, "Received URDF from param server");
 }
 
-}  // namespace
+}  // namespace ros_control_boilerplate

--- a/src/sim_hw_interface.cpp
+++ b/src/sim_hw_interface.cpp
@@ -44,9 +44,8 @@
 
 namespace ros_control_boilerplate
 {
-SimHWInterface::SimHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model)
-  : GenericHWInterface(nh, urdf_model)
-  , name_("sim_hw_interface")
+SimHWInterface::SimHWInterface(ros::NodeHandle& nh, urdf::Model* urdf_model)
+  : GenericHWInterface(nh, urdf_model), name_("sim_hw_interface")
 {
   // Load rosparams
   ros::NodeHandle rpnh(nh_, "hardware_interface");
@@ -71,12 +70,12 @@ void SimHWInterface::init()
   ROS_INFO_NAMED(name_, "SimHWInterface Ready.");
 }
 
-void SimHWInterface::read(ros::Duration &elapsed_time)
+void SimHWInterface::read(ros::Duration& elapsed_time)
 {
   // No need to read since our write() command populates our state for us
 }
 
-void SimHWInterface::write(ros::Duration &elapsed_time)
+void SimHWInterface::write(ros::Duration& elapsed_time)
 {
   // Safety
   enforceLimits(elapsed_time);
@@ -118,13 +117,13 @@ void SimHWInterface::write(ros::Duration &elapsed_time)
   }
 }
 
-void SimHWInterface::enforceLimits(ros::Duration &period)
+void SimHWInterface::enforceLimits(ros::Duration& period)
 {
   // Enforces position and velocity
   pos_jnt_sat_interface_.enforceLimits(period);
 }
 
-void SimHWInterface::positionControlSimulation(ros::Duration &elapsed_time, const std::size_t joint_id)
+void SimHWInterface::positionControlSimulation(ros::Duration& elapsed_time, const std::size_t joint_id)
 {
   const double max_delta_pos = joint_velocity_limits_[joint_id] * elapsed_time.toSec();
 
@@ -135,7 +134,7 @@ void SimHWInterface::positionControlSimulation(ros::Duration &elapsed_time, cons
   joint_position_[joint_id] += delta_pos;
 
   // Bypass max velocity p controller:
-  //joint_position_[joint_id] = joint_position_command_[joint_id];
+  // joint_position_[joint_id] = joint_position_command_[joint_id];
 
   // Calculate velocity based on change in positions
   if (elapsed_time.toSec() > 0)
@@ -149,4 +148,4 @@ void SimHWInterface::positionControlSimulation(ros::Duration &elapsed_time, cons
   joint_position_prev_[joint_id] = joint_position_[joint_id];
 }
 
-}  // namespace
+}  // namespace ros_control_boilerplate

--- a/src/sim_hw_main.cpp
+++ b/src/sim_hw_main.cpp
@@ -50,13 +50,13 @@ int main(int argc, char** argv)
   spinner.start();
 
   // Create the hardware interface specific to your robot
-  boost::shared_ptr<ros_control_boilerplate::SimHWInterface> sim_hw_interface
-    (new ros_control_boilerplate::SimHWInterface(nh));
+  boost::shared_ptr<ros_control_boilerplate::SimHWInterface> sim_hw_interface(
+      new ros_control_boilerplate::SimHWInterface(nh));
   sim_hw_interface->init();
 
   // Start the control loop
   ros_control_boilerplate::GenericHWControlLoop control_loop(nh, sim_hw_interface);
-  control_loop.run(); // Blocks until shutdown signal recieved
+  control_loop.run();  // Blocks until shutdown signal recieved
 
   return 0;
 }

--- a/src/tools/controller_to_csv.cpp
+++ b/src/tools/controller_to_csv.cpp
@@ -47,11 +47,7 @@
 
 namespace ros_control_boilerplate
 {
-
-ControllerToCSV::ControllerToCSV(const std::string& topic)
-  : nh_("~")
-  , first_update_(true)
-  , recording_started_(true)
+ControllerToCSV::ControllerToCSV(const std::string& topic) : nh_("~"), first_update_(true), recording_started_(true)
 {
   // Load rosparams
   ros::NodeHandle rpsnh(nh_, name_);
@@ -61,8 +57,7 @@ ControllerToCSV::ControllerToCSV(const std::string& topic)
 
   ROS_INFO_STREAM_NAMED(name_, "Subscribing to " << topic);
   // State subscriber
-  state_sub_ = nh_.subscribe<control_msgs::JointTrajectoryControllerState>(
-      topic, 1, &ControllerToCSV::stateCB, this);
+  state_sub_ = nh_.subscribe<control_msgs::JointTrajectoryControllerState>(topic, 1, &ControllerToCSV::stateCB, this);
 
   // Wait for states to populate
   waitForSubscriber(state_sub_);
@@ -101,7 +96,7 @@ void ControllerToCSV::stateCB(const control_msgs::JointTrajectoryControllerState
     // Record current time
     timestamps_.push_back(ros::Time::now());
   }
-  else // only record at freq
+  else  // only record at freq
   {
     current_state_ = *state;
   }
@@ -120,7 +115,7 @@ void ControllerToCSV::startRecording(const std::string& file_name)
   recording_started_ = true;
 
   // Start sampling loop
-  if (!recordAll()) // only record at the specified frequency
+  if (!recordAll())  // only record at the specified frequency
   {
     ros::Duration update_freq = ros::Duration(1.0 / record_hz_);
     non_realtime_loop_ = nh_.createTimer(update_freq, &ControllerToCSV::update, this);
@@ -139,10 +134,12 @@ void ControllerToCSV::update(const ros::TimerEvent& event)
     }
     first_update_ = false;
   }
-  else // if (event.last_real > 0)
+  else  // if (event.last_real > 0)
   {
     const double freq = 1.0 / (event.current_real - event.last_real).toSec();
-    ROS_INFO_STREAM_THROTTLE_NAMED(2, name_, "Updating at " << freq << " hz, total: " << (ros::Time::now() - timestamps_.front()).toSec() << " seconds");
+    ROS_INFO_STREAM_THROTTLE_NAMED(2, name_,
+                                   "Updating at " << freq << " hz, total: "
+                                                  << (ros::Time::now() - timestamps_.front()).toSec() << " seconds");
   }
   // Record state
   states_.push_back(current_state_);
@@ -174,12 +171,9 @@ bool ControllerToCSV::writeToFile()
   output_file << "timestamp,";
   for (std::size_t j = 0; j < states_[0].joint_names.size(); ++j)
   {
-    output_file << states_[0].joint_names[j] << "_desired_pos,"
-                << states_[0].joint_names[j] << "_desired_vel,"
-                << states_[0].joint_names[j] << "_actual_pos,"
-                << states_[0].joint_names[j] << "_actual_vel,"
-                << states_[0].joint_names[j] << "_error_pos,"
-                << states_[0].joint_names[j] << "_error_vel,";
+    output_file << states_[0].joint_names[j] << "_desired_pos," << states_[0].joint_names[j] << "_desired_vel,"
+                << states_[0].joint_names[j] << "_actual_pos," << states_[0].joint_names[j] << "_actual_vel,"
+                << states_[0].joint_names[j] << "_error_pos," << states_[0].joint_names[j] << "_error_vel,";
   }
   output_file << std::endl;
 
@@ -198,12 +192,9 @@ bool ControllerToCSV::writeToFile()
     for (std::size_t j = 0; j < states_[i].joint_names.size(); ++j)
     {
       // Output State
-      output_file << states_[i].desired.positions[j] << ","
-                  << states_[i].desired.velocities[j] << ","
-                  << states_[i].actual.positions[j] << ","
-                  << states_[i].actual.velocities[j] << ","
-                  << states_[i].error.positions[j] << ","
-                  << states_[i].error.velocities[j] << ",";
+      output_file << states_[i].desired.positions[j] << "," << states_[i].desired.velocities[j] << ","
+                  << states_[i].actual.positions[j] << "," << states_[i].actual.velocities[j] << ","
+                  << states_[i].error.positions[j] << "," << states_[i].error.velocities[j] << ",";
     }
 
     output_file << std::endl;
@@ -236,7 +227,7 @@ bool ControllerToCSV::waitForSubscriber(const ros::Subscriber& sub, const double
     if (ros::Time::now() > max_time)
     {
       ROS_WARN_STREAM_NAMED(name_, "Topic '" << sub.getTopic() << "' unable to connect to any publishers within "
-                                                      << wait_time << " seconds.");
+                                             << wait_time << " seconds.");
       return false;
     }
     ros::spinOnce();
@@ -253,11 +244,11 @@ bool ControllerToCSV::waitForSubscriber(const ros::Subscriber& sub, const double
   {
     double duration = (ros::Time::now() - start_time).toSec();
     ROS_DEBUG_STREAM_NAMED(name_, "Topic '" << sub.getTopic() << "' took " << duration
-                                                     << " seconds to connect to a subscriber. "
-                                                        "Connected to " << num_existing_subscribers
-                                                     << " total subsribers");
+                                            << " seconds to connect to a subscriber. "
+                                               "Connected to "
+                                            << num_existing_subscribers << " total subsribers");
   }
   return true;
 }
 
-}  // end namespace
+}  // namespace ros_control_boilerplate

--- a/src/tools/controller_to_csv_main.cpp
+++ b/src/tools/controller_to_csv_main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char** argv)
   ros_control_boilerplate::ControllerToCSV converter(topic);
   converter.startRecording(csv_path);
 
-  ROS_INFO_STREAM_NAMED("main","Type Ctrl-C to end and save");
+  ROS_INFO_STREAM_NAMED("main", "Type Ctrl-C to end and save");
   ros::spin();
 
   ROS_INFO_STREAM_NAMED("main", "Shutting down.");

--- a/src/tools/csv_to_controller_main.cpp
+++ b/src/tools/csv_to_controller_main.cpp
@@ -57,10 +57,10 @@ int main(int argc, char** argv)
   // Get file name
   if (FLAGS_csv_path.empty())
   {
-    ROS_ERROR_STREAM_NAMED("csv_to_controller","No file name passed in");
+    ROS_ERROR_STREAM_NAMED("csv_to_controller", "No file name passed in");
     return 0;
   }
-  ROS_INFO_STREAM_NAMED("csv_to_controller","Reading from file " << FLAGS_csv_path);
+  ROS_INFO_STREAM_NAMED("csv_to_controller", "Reading from file " << FLAGS_csv_path);
 
   // Allow the action server to recieve and send ros messages
   ros::AsyncSpinner spinner(2);

--- a/src/tools/keyboard_teleop.cpp
+++ b/src/tools/keyboard_teleop.cpp
@@ -71,7 +71,7 @@
 #define KEYCODE_x 0x78
 #define KEYCODE_y 0x79
 #define KEYCODE_z 0x7a
-#define KEYCODE_ESCAPE  0x1B
+#define KEYCODE_ESCAPE 0x1B
 
 int kfd = 0;
 struct termios cooked, raw;
@@ -85,9 +85,7 @@ void quit(int sig)
 class TeleopJointsKeyboard
 {
 public:
-
-  TeleopJointsKeyboard()
-    : has_recieved_joints_(false)
+  TeleopJointsKeyboard() : has_recieved_joints_(false)
   {
     std::cout << "init " << std::endl;
     // TODO: make this robot agonistic
@@ -98,11 +96,12 @@ public:
   }
 
   ~TeleopJointsKeyboard()
-  { }
+  {
+  }
 
   void stateCallback(const sensor_msgs::JointStateConstPtr& msg)
   {
-    if(msg->position.size() != 7)
+    if (msg->position.size() != 7)
     {
       ROS_ERROR_STREAM("Not enough joints!");
       exit(-1);
@@ -113,8 +112,8 @@ public:
       cmd_.data = msg->position;
 
     // Debug
-    //std::copy(cmd_.data.begin(), cmd_.data.end(), std::ostream_iterator<double>(std::cout, " "));
-    //std::cout << std::endl;
+    // std::copy(cmd_.data.begin(), cmd_.data.end(), std::ostream_iterator<double>(std::cout, " "));
+    // std::cout << std::endl;
 
     // Important safety feature
     has_recieved_joints_ = true;
@@ -123,12 +122,12 @@ public:
   void keyboardLoop()
   {
     char c;
-    bool dirty=false;
+    bool dirty = false;
 
     // get the console in raw mode
     tcgetattr(kfd, &cooked);
     memcpy(&raw, &cooked, sizeof(struct termios));
-    raw.c_lflag &=~ (ICANON | ECHO);
+    raw.c_lflag &= ~(ICANON | ECHO);
     // Setting a new line, then end of file
     raw.c_cc[VEOL] = 1;
     raw.c_cc[VEOF] = 2;
@@ -147,75 +146,75 @@ public:
 
     double delta_dist = 0.005;
 
-    for(;;)
+    for (;;)
     {
       // get the next event from the keyboard
-      if(read(kfd, &c, 1) < 0)
+      if (read(kfd, &c, 1) < 0)
       {
         perror("read():");
         exit(-1);
       }
 
       dirty = true;
-      switch(c)
+      switch (c)
       {
         case KEYCODE_q:
-          cmd_.data[0] = cmd_.data[0] + delta_dist; // radians
+          cmd_.data[0] = cmd_.data[0] + delta_dist;  // radians
           break;
         case KEYCODE_a:
-          cmd_.data[0] = cmd_.data[0] - delta_dist; // radians
+          cmd_.data[0] = cmd_.data[0] - delta_dist;  // radians
           break;
 
         case KEYCODE_w:
-          cmd_.data[1] = cmd_.data[1] + delta_dist; // radians
+          cmd_.data[1] = cmd_.data[1] + delta_dist;  // radians
           break;
         case KEYCODE_s:
-          cmd_.data[1] = cmd_.data[1] - delta_dist; // radians
+          cmd_.data[1] = cmd_.data[1] - delta_dist;  // radians
           break;
 
         case KEYCODE_e:
-          cmd_.data[2] = cmd_.data[2] + delta_dist; // radians
+          cmd_.data[2] = cmd_.data[2] + delta_dist;  // radians
           break;
         case KEYCODE_d:
-          cmd_.data[2] = cmd_.data[2] - delta_dist; // radians
+          cmd_.data[2] = cmd_.data[2] - delta_dist;  // radians
           break;
 
         case KEYCODE_r:
-          cmd_.data[3] = cmd_.data[3] + delta_dist; // radians
+          cmd_.data[3] = cmd_.data[3] + delta_dist;  // radians
           break;
         case KEYCODE_f:
-          cmd_.data[3] = cmd_.data[3] - delta_dist; // radians
+          cmd_.data[3] = cmd_.data[3] - delta_dist;  // radians
           break;
 
         case KEYCODE_t:
-          cmd_.data[4] = cmd_.data[4] + delta_dist; // radians
+          cmd_.data[4] = cmd_.data[4] + delta_dist;  // radians
           break;
         case KEYCODE_g:
-          cmd_.data[4] = cmd_.data[4] - delta_dist; // radians
+          cmd_.data[4] = cmd_.data[4] - delta_dist;  // radians
           break;
 
         case KEYCODE_y:
-          cmd_.data[5] = cmd_.data[5] + delta_dist; // radians
+          cmd_.data[5] = cmd_.data[5] + delta_dist;  // radians
           break;
         case KEYCODE_h:
-          cmd_.data[5] = cmd_.data[5] - delta_dist; // radians
+          cmd_.data[5] = cmd_.data[5] - delta_dist;  // radians
           break;
 
         case KEYCODE_u:
-          cmd_.data[6] = cmd_.data[6] + delta_dist; // radians
+          cmd_.data[6] = cmd_.data[6] + delta_dist;  // radians
           break;
         case KEYCODE_j:
-          cmd_.data[6] = cmd_.data[6] - delta_dist; // radians
+          cmd_.data[6] = cmd_.data[6] - delta_dist;  // radians
           break;
 
-        case  KEYCODE_ESCAPE:
+        case KEYCODE_ESCAPE:
           std::cout << std::endl;
           std::cout << "Exiting " << std::endl;
           quit(0);
           break;
 
         default:
-          std::cout << "CODE: "  << c << std::endl;
+          std::cout << "CODE: " << c << std::endl;
           dirty = false;
       }
 
@@ -225,8 +224,10 @@ public:
         // Important safety feature
         if (!has_recieved_joints_)
         {
-          ROS_ERROR_STREAM_NAMED("joint_teleop","Unable to send joint commands because robot state is invalid");
-        } else {
+          ROS_ERROR_STREAM_NAMED("joint_teleop", "Unable to send joint commands because robot state is invalid");
+        }
+        else
+        {
           std::cout << ".";
           joints_pub_.publish(cmd_);
         }
@@ -235,19 +236,17 @@ public:
   }
 
 private:
-
   ros::NodeHandle nh_;
   ros::Publisher joints_pub_;
   ros::Subscriber joints_sub_;
   std_msgs::Float64MultiArray cmd_;
   bool has_recieved_joints_;
-
 };
 
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "joints_teleop_keyboard");
-  signal(SIGINT,quit);
+  signal(SIGINT, quit);
 
   // NOTE: We run the ROS loop in a separate thread as external calls such
   // as service callbacks to load controllers can block the (main) control loop
@@ -257,5 +256,5 @@ int main(int argc, char** argv)
   TeleopJointsKeyboard teleop;
   teleop.keyboardLoop();
 
-  return(0);
+  return (0);
 }

--- a/src/tools/test_trajectory.cpp
+++ b/src/tools/test_trajectory.cpp
@@ -54,24 +54,21 @@ public:
   /**
    * \brief Constructor
    */
-  TestTrajectory()
-    : nh_private_("~")
+  TestTrajectory() : nh_private_("~")
   {
     std::string action_topic;
     nh_private_.getParam("action_topic", action_topic);
     if (action_topic.empty())
     {
-      ROS_FATAL_STREAM_NAMED(
-          "test_trajectory",
-          "Not follow joint trajectory action topic found on the parameter server");
+      ROS_FATAL_STREAM_NAMED("test_trajectory",
+                             "Not follow joint trajectory action topic found on the parameter server");
       exit(-1);
     }
     ROS_INFO_STREAM_NAMED("test_trajectory", "Connecting to action " << action_topic);
 
     // create the action client
     // true causes the client to spin its own thread
-    actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> action_client(
-        action_topic, true);
+    actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> action_client(action_topic, true);
 
     ROS_INFO_NAMED("test_trajetory", "Waiting for action server to start.");
     // wait for the action server to start
@@ -114,17 +111,16 @@ public:
     nh_private_.getParam("hardware_interface/joints", joint_names);
     if (joint_names.size() == 0)
     {
-      ROS_FATAL_STREAM_NAMED(
-          "init",
-          "Not joints found on parameter server for controller, did you load the proper yaml file?"
-              << " Namespace: " << nh_private_.getNamespace() << "/hardware_interface/joints");
+      ROS_FATAL_STREAM_NAMED("init",
+                             "Not joints found on parameter server for controller, did you load the proper yaml file?"
+                                 << " Namespace: " << nh_private_.getNamespace() << "/hardware_interface/joints");
       exit(-1);
     }
 
     nh_private_.getParam("min_joint_value", min_joint_value);
     nh_private_.getParam("max_joint_value", max_joint_value);
-    ROS_DEBUG_STREAM_NAMED("test_trajectory", "Creating trajectory with joint values from "
-                                                  << min_joint_value << " to " << max_joint_value);
+    ROS_DEBUG_STREAM_NAMED("test_trajectory", "Creating trajectory with joint values from " << min_joint_value << " to "
+                                                                                            << max_joint_value);
 
     // Create header
     trajectory_msgs::JointTrajectory trajectory;
@@ -164,7 +160,7 @@ private:
 typedef boost::shared_ptr<TestTrajectory> TestTrajectoryPtr;
 typedef boost::shared_ptr<const TestTrajectory> TestTrajectoryConstPtr;
 
-}  // end namespace
+}  // namespace ros_control_boilerplate
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
This PR does some cleanups on the project code:
- Adds the moveit clang-format config and formats all code according to it.
- Tries to get closer to passing ```catkin_lint -W2```. The remaining warnings are a result of the missing run dependencies for the rrbot demo, which we cannot easily get rid off without turning that into a seperate package.
- Adds checks for both to the CI.

Are there any opinions on this? As these are mainly cosmetic changes i would go ahead and merge them soon otherwise.

Closes #39.