### PR TITLE
Increase required cmake version to fix CMake CMP0048 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ros_control_boilerplate)
 
 # C++ 11


### PR DESCRIPTION
This is a recommended change from the [noetic migration guide](https://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning). It should also get rid of current jenkins buildfarm warnings (Quality Gate: Unstable) for ubuntu focal and debian buster. This version is guaranteed to exist in Noetic systems by REP 3.

As this fix is so straightforward i will just wait until a CI run and then merge it.