### PR TITLE
Enable usage of GenericHWInterfaces inside a combined_robot_hw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,3 +169,5 @@ install(TARGETS
 
 # Install header files
 install(DIRECTORY include/${PROJECT_NAME}/   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+# Install plugin description
+install(FILES sim_hw_interface_plugin.xml    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,13 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(catkin REQUIRED COMPONENTS
   actionlib
   cmake_modules
+  combined_robot_hw
   control_msgs
   control_toolbox
   controller_manager
   hardware_interface
   joint_limits_interface
+  pluginlib
   roscpp
   rosparam_shortcuts
   sensor_msgs
@@ -33,11 +35,13 @@ catkin_package(
     include
   CATKIN_DEPENDS
     actionlib
+    combined_robot_hw
     control_msgs
     control_toolbox
     controller_manager
     hardware_interface
     joint_limits_interface
+    pluginlib
     roscpp
     rosparam_shortcuts
     sensor_msgs

--- a/include/ros_control_boilerplate/combinable_generic_hw.h
+++ b/include/ros_control_boilerplate/combinable_generic_hw.h
@@ -1,0 +1,163 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Robert Wilbrandt
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Robert Wilbrandt
+   Desc:   Adapter class that enables usage of a GenericHWInterface in a
+   combined_robot_hw
+*/
+
+#ifndef ROS_CONTROL_BOILERPLATE__COMBINABLE_GENERIC_HW_H
+#define ROS_CONTROL_BOILERPLATE__COMBINABLE_GENERIC_HW_H
+
+#include <memory>
+#include <hardware_interface/robot_hw.h>
+#include <ros_control_boilerplate/generic_hw_interface.h>
+
+namespace ros_control_boilerplate
+{
+/**
+ * \brief Adapter for GenericHWInterfaces in combined_robot_hw
+ *
+ * A GenericHWInterface can not be used in a combined_robot_hw directly, as it doesn't have a parameterless constructor
+ * and the init() signature is not suitable. This class provides an adapter that enables this use case with minimal
+ * effort.
+ *
+ * In order to use this adapter, you need to follow these steps:
+ * - Create a plugin description file and export it in your package xml.
+ * - Import this header and the pluginlib/class_loader_macros.hpp header file
+ *   in your GenericHWInterface implementation source file.
+ * - Add a line like this to the bottom of your GenericHWInterface:
+ *   \code{.cpp}
+ *     PLUGINLIB_EXPORT_CLASS(
+ *       ros_control_boilerplate::CombinableGenericHWAdapter<YourHWInterface>,
+ *       hardware_interface::RobotHW
+ *     )
+ *    \endcode
+ *
+ * \tparam ConcreteGenericHW Concrete GenericHWInterface to adapt
+ */
+template <typename ConcreteGenericHW>
+class CombinableGenericHW : public hardware_interface::RobotHW
+{
+public:
+  /** \brief Constructor */
+  CombinableGenericHW();
+
+  /** \brief Destructor */
+  virtual ~CombinableGenericHW();
+
+  /** \brief Creates and initializes the adapted GenericHWInterface
+   *
+   * \param root_nh Root level ROS node handle
+   * \param robot_hw_nh ROS node handle for the robot namespace
+   *
+   * \returns Always returns true, as these steps cannot fail
+   */
+  virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) override;
+
+  /** \brief Reads the state from the robot hardware
+   *
+   * \note This just delegates to the adapted GenericHWInterface
+   *
+   * \param time Current time
+   * \param period Duration of current control loop iteration
+   */
+  virtual void read(const ros::Time& time, const ros::Duration& period) override;
+
+  /** \brief Write commands to the robot hardware
+   *
+   * \note This just delegates to the adapted GenericHWInterface
+   *
+   * \param time Current time
+   * \param period Duration of the current control loop iteration
+   */
+  virtual void write(const ros::Time& time, const ros::Duration& period) override;
+
+  /** \brief Check if given set of controllers is allowed to run simultaneously
+   *
+   * \note This just delegates to the adapted GenericHWInterface
+   *
+   * \param info Set of controllers to check
+   */
+  virtual bool checkForConflict(const std::list<hardware_interface::ControllerInfo>& info) const override;
+
+  /** \brief Check if given controller switches are currently possible and prepare for them
+   *
+   * \note This just delegates to the adapted GenericHWInterface
+   *
+   * \param start_list Controllers that would get started, disjoint from stop_list
+   * \param stop_list Controllers that would get stopped, disjoint from start_list
+   *
+   * \returns If this set of controller switches is currently possible
+   */
+  virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                             const std::list<hardware_interface::ControllerInfo>& stop_list) override;
+
+  /** \brief Perform all hardware-side changes to allow for controller switches
+   *
+   * \note This just delegates to the adapted GenericHWInterface
+   *
+   * \param start_list Controllers that would get started, disjoint from stop_list
+   * \param stop_list Controllers that would get stopped, disjoint from start_list
+   */
+  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                        const std::list<hardware_interface::ControllerInfo>& stop_list) override;
+
+  /** \brief Return the state of the last doSwitch()
+   *
+   * \note This just delegates to the adapted GenericHWInterface
+   *
+   * \returns State of the last doSwitch()
+   */
+  virtual RobotHW::SwitchState switchResult() const override;
+
+  /** \brief Return the state of the last doSwitch() for a given controller
+   *
+   * \note This just delegates to the adapted GenericHWInterface
+   *
+   * \param controller Controller to check state for
+   *
+   * \returns State of the last doSwitch() for controller
+   */
+  virtual RobotHW::SwitchState switchResult(const hardware_interface::ControllerInfo& controller) const override;
+
+protected:
+  std::shared_ptr<GenericHWInterface> adapted_hw_interface_; /*!< Adapted GenericHWInterface */
+};
+
+}  // namespace ros_control_boilerplate
+
+#include <ros_control_boilerplate/combinable_generic_hw_impl.hpp>
+
+#endif

--- a/include/ros_control_boilerplate/combinable_generic_hw.h
+++ b/include/ros_control_boilerplate/combinable_generic_hw.h
@@ -65,6 +65,8 @@ namespace ros_control_boilerplate
  *     )
  *    \endcode
  *
+ *  An example of this procedure is implemented for SimHWInterface.
+ *
  * \tparam ConcreteGenericHW Concrete GenericHWInterface to adapt
  */
 template <typename ConcreteGenericHW>

--- a/include/ros_control_boilerplate/combinable_generic_hw_impl.hpp
+++ b/include/ros_control_boilerplate/combinable_generic_hw_impl.hpp
@@ -1,0 +1,117 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Robert Wilbrandt
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Robert Wilbrandt
+   Desc:   Implementation of adapter class that enables usage of a
+   GenericHWInterface in a combined_robot_hw
+*/
+
+#ifndef ROS_CONTROL_BOILERPLATE__COMBINABLE_GENERIC_HW_IMPL_H
+#define ROS_CONTROL_BOILERPLATE__COMBINABLE_GENERIC_HW_IMPL_H
+
+#include <ros_control_boilerplate/combinable_generic_hw.h>
+
+namespace ros_control_boilerplate
+{
+template <typename ConcreteGenericHW>
+CombinableGenericHW<ConcreteGenericHW>::CombinableGenericHW() : adapted_hw_interface_{ nullptr }
+{
+}
+
+template <typename ConcreteGenericHW>
+CombinableGenericHW<ConcreteGenericHW>::~CombinableGenericHW()
+{
+}
+
+template <typename ConcreteGenericHW>
+bool CombinableGenericHW<ConcreteGenericHW>::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
+{
+  adapted_hw_interface_.reset(new ConcreteGenericHW(robot_hw_nh));
+  adapted_hw_interface_->init();
+
+  registerInterfaceManager(adapted_hw_interface_.get());
+
+  return true;
+}
+
+template <typename ConcreteGenericHW>
+void CombinableGenericHW<ConcreteGenericHW>::read(const ros::Time& time, const ros::Duration& period)
+{
+  adapted_hw_interface_->read(time, period);
+}
+
+template <typename ConcreteGenericHW>
+void CombinableGenericHW<ConcreteGenericHW>::write(const ros::Time& time, const ros::Duration& period)
+{
+  adapted_hw_interface_->write(time, period);
+}
+
+template <typename ConcreteGenericHW>
+bool CombinableGenericHW<ConcreteGenericHW>::checkForConflict(
+    const std::list<hardware_interface::ControllerInfo>& info) const
+{
+  return adapted_hw_interface_->checkForConflict(info);
+}
+
+template <typename ConcreteGenericHW>
+bool CombinableGenericHW<ConcreteGenericHW>::prepareSwitch(
+    const std::list<hardware_interface::ControllerInfo>& start_list,
+    const std::list<hardware_interface::ControllerInfo>& stop_list)
+{
+  return adapted_hw_interface_->prepareSwitch(start_list, stop_list);
+}
+
+template <typename ConcreteGenericHW>
+void CombinableGenericHW<ConcreteGenericHW>::doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                                                      const std::list<hardware_interface::ControllerInfo>& stop_list)
+{
+  adapted_hw_interface_->doSwitch(start_list, stop_list);
+}
+
+template <typename ConcreteGenericHW>
+hardware_interface::RobotHW::SwitchState CombinableGenericHW<ConcreteGenericHW>::switchResult() const
+{
+  return adapted_hw_interface_->switchResult();
+}
+
+template <typename ConcreteGenericHW>
+hardware_interface::RobotHW::SwitchState
+CombinableGenericHW<ConcreteGenericHW>::switchResult(const hardware_interface::ControllerInfo& controller) const
+{
+  return adapted_hw_interface_->switchResult(controller);
+}
+
+}  // namespace ros_control_boilerplate
+
+#endif

--- a/package.xml
+++ b/package.xml
@@ -31,6 +31,8 @@
   <build_depend>libgflags-dev</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>rosparam_shortcuts</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>combined_robot_hw</build_depend>
 
   <run_depend>hardware_interface</run_depend>
   <run_depend>controller_manager</run_depend>
@@ -45,6 +47,8 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>rosparam_shortcuts</run_depend>
+  <run_depend>pluginlib</run_depend>
+  <run_depend>combined_robot_hw</run_depend>
 
   <!-- These are needed if you want to run the rrbot simulation demo -->
   <!--<run_depend>xacro</run_depend>-->

--- a/package.xml
+++ b/package.xml
@@ -57,5 +57,6 @@
   <!--<run_depend>rviz</run_depend>-->
 
   <export>
+    <hardware_interface plugin="${prefix}/sim_hw_interface_plugin.xml" />
   </export>
 </package>

--- a/rrbot_control/CMakeLists.txt
+++ b/rrbot_control/CMakeLists.txt
@@ -37,8 +37,8 @@ install(TARGETS
 
 # Install executables
 install(TARGETS
-    rrbot_hw_main
     rrbot_combined_hw_main
+    rrbot_hw_main
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/rrbot_control/CMakeLists.txt
+++ b/rrbot_control/CMakeLists.txt
@@ -19,6 +19,13 @@ target_link_libraries(rrbot_hw_main
   ${catkin_LIBRARIES}
 )
 
+# Combined control executable
+add_executable(rrbot_combined_hw_main src/rrbot_combined_hw_main.cpp)
+target_link_libraries(rrbot_combined_hw_main
+  generic_hw_control_loop
+  ${catkin_LIBRARIES}
+)
+
 ## Install ------------------------------------------------------------
 
 # Install libraries
@@ -31,6 +38,7 @@ install(TARGETS
 # Install executables
 install(TARGETS
     rrbot_hw_main
+    rrbot_combined_hw_main
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/rrbot_control/config/control_loop.yaml
+++ b/rrbot_control/config/control_loop.yaml
@@ -1,0 +1,4 @@
+# Settings for the ros_control control loop -----------------------------------
+generic_hw_control_loop:
+  loop_hz: 300                      # Frequency of control loop
+  cycle_time_error_threshold: 0.01  # Maximum allowed timing deviation in [s]

--- a/rrbot_control/config/rrbot_combined_robot_hardware.yaml
+++ b/rrbot_control/config/rrbot_combined_robot_hardware.yaml
@@ -1,0 +1,39 @@
+# combined_robot_hw Settings --------------------------------------------------
+
+# These are the names of the individual hardware interfaces that will be
+# loaded. They are also the namespaces in which each individual hardware
+# interface will run.
+#
+# In this example, we will use two SimHWInterfaces, with each one controlling
+# one joint.
+robot_hardware:
+  - joint_1_hw
+  - joint_2_hw
+
+joint_1_hw:
+  # combined_robot_hw Settings --------------------------------------
+
+  # This has to match the name specified in the plugin description
+  type: ros_control_boilerplate/SimHWInterface
+  joints:
+    - joint1
+
+  # ros_control_boilerplate Settings --------------------------------
+  hardware_interface:
+    joints:                  # Simulate only one joint
+      - joint1
+    sim_control_mode: 0      # 0: position, 1: velocity
+
+joint_2_hw:
+  # combined_robot_hw Settings --------------------------------------
+
+  # This has to match the name specified in the plugin description
+  type: ros_control_boilerplate/SimHWInterface
+  joints:
+    - joint2
+
+  # ros_control_boilerplate Settings --------------------------------
+  hardware_interface:
+    joints:
+      - joint2
+    sim_control_mode: 0

--- a/rrbot_control/config/rrbot_controllers.yaml
+++ b/rrbot_control/config/rrbot_controllers.yaml
@@ -1,16 +1,3 @@
-# ros_control_boilerplate Settings -----------------------
-# Settings for ros_control control loop
-generic_hw_control_loop:
-  loop_hz: 300
-  cycle_time_error_threshold: 0.01
-
-# Settings for ros_control hardware interface
-hardware_interface:
-   joints:
-      - joint1
-      - joint2
-   sim_control_mode: 0 # 0: position, 1: velocity
-
 # Publish all joint states ----------------------------------
 # Creates the /joint_states topic necessary in ROS
 joint_state_controller:

--- a/rrbot_control/config/rrbot_robot_hardware.yaml
+++ b/rrbot_control/config/rrbot_robot_hardware.yaml
@@ -1,0 +1,8 @@
+# ros_control_boilerplate Settings ---------------------------------------------
+
+# Settings for ros_control hardware interface
+hardware_interface:
+   joints:              # Simulate both joints
+      - joint1
+      - joint2
+   sim_control_mode: 0  # 0: position, 1: velocity

--- a/rrbot_control/launch/rrbot_combined_simulation.launch
+++ b/rrbot_control/launch/rrbot_combined_simulation.launch
@@ -10,15 +10,15 @@
   <param name="robot_description" command="$(find xacro)/xacro '$(find rrbot_description)/urdf/rrbot.xacro'" />
 
   <group ns="rrbot">
-
     <!-- Load hardware interface -->
-    <node name="rrbot_hardware_interface" pkg="ros_control_boilerplate" type="sim_hw_main"
-          output="screen" launch-prefix="$(arg launch_prefix)"/>
+    <node name="rrbot_combined_hardware_interface" pkg="ros_control_boilerplate" type="rrbot_combined_hw_main"
+      output="screen" launch-prefix="$(arg launch_prefix)">
 
-    <!-- Load hardware settings -->
-    <rosparam file="$(find ros_control_boilerplate)/rrbot_control/config/rrbot_robot_hardware.yaml" command="load"/>
+      <!-- Hardware settings -->
+      <rosparam file="$(find ros_control_boilerplate)/rrbot_control/config/rrbot_combined_robot_hardware.yaml" />
+    </node>
 
-    <!-- Load control loop settings -->
+    <!-- Control loop settings -->
     <rosparam file="$(find ros_control_boilerplate)/rrbot_control/config/control_loop.yaml" command="load"/>
 
     <!-- Load controller settings -->
@@ -32,5 +32,6 @@
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
   </group>
+
 
 </launch>

--- a/rrbot_control/launch/rrbot_hardware.launch
+++ b/rrbot_control/launch/rrbot_hardware.launch
@@ -15,6 +15,12 @@
     <node name="rrbot_hardware_interface" pkg="ros_control_boilerplate" type="rrbot_hw_main"
           output="screen" launch-prefix="$(arg launch_prefix)"/>
 
+    <!-- Load hardware settings -->
+    <rosparam file="$(find ros_control_boilerplate)/rrbot_control/config/rrbot_robot_hardware.yaml" command="load"/>
+
+    <!-- Load control loop settings -->
+    <rosparam file="$(find ros_control_boilerplate)/rrbot_control/config/control_loop.yaml" command="load"/>
+
     <!-- Load controller settings -->
     <rosparam file="$(find ros_control_boilerplate)/rrbot_control/config/rrbot_controllers.yaml" command="load"/>
 

--- a/rrbot_control/src/rrbot_combined_hw_main.cpp
+++ b/rrbot_control/src/rrbot_combined_hw_main.cpp
@@ -1,0 +1,63 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, Robert Wilbrandt
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Robert Wilbrandt
+   Desc:   Example ros_control main() entry point for controlling robots using
+   a combined_robot_hw in ROS
+*/
+
+#include <ros_control_boilerplate/generic_hw_control_loop.h>
+#include <combined_robot_hw/combined_robot_hw.h>
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "rrbot_combined_hw_interface");
+  ros::NodeHandle nh;
+  ros::NodeHandle priv_nh("~");
+
+  // NOTE: We run the ROS loop in a separate thread as external calls such
+  // as service callbacks to load controllers can block the (main) control loop
+  ros::AsyncSpinner spinner(3);
+  spinner.start();
+
+  // Create the combined_robot_hw
+  std::shared_ptr<combined_robot_hw::CombinedRobotHW> combined_hw_interface(new combined_robot_hw::CombinedRobotHW());
+  combined_hw_interface->init(nh, priv_nh);
+
+  // Start the control loop
+  ros_control_boilerplate::GenericHWControlLoop control_loop(nh, combined_hw_interface);
+  control_loop.run();  // Blocks until shutdown signal recieved
+
+  return 0;
+}

--- a/sim_hw_interface_plugin.xml
+++ b/sim_hw_interface_plugin.xml
@@ -1,0 +1,9 @@
+<library path="lib/libsim_hw_interface">
+  <class name="ros_control_boilerplate/SimHWInterface"
+    type="ros_control_boilerplate::CombinableGenericHW<ros_control_boilerplate::SimHWInterface>"
+      base_class_type="hardware_interface::RobotHW">
+    <description>
+      Simple kinematic robot simulation
+    </description>
+  </class>
+</library>

--- a/src/sim_hw_interface.cpp
+++ b/src/sim_hw_interface.cpp
@@ -42,6 +42,10 @@
 // ROS parameter loading
 #include <rosparam_shortcuts/rosparam_shortcuts.h>
 
+// Pluginlib export for combined_robot_hw
+#include <ros_control_boilerplate/combinable_generic_hw.h>
+#include <pluginlib/class_list_macros.hpp>
+
 namespace ros_control_boilerplate
 {
 SimHWInterface::SimHWInterface(ros::NodeHandle& nh, urdf::Model* urdf_model)
@@ -149,3 +153,6 @@ void SimHWInterface::positionControlSimulation(ros::Duration& elapsed_time, cons
 }
 
 }  // namespace ros_control_boilerplate
+
+PLUGINLIB_EXPORT_CLASS(ros_control_boilerplate::CombinableGenericHW<ros_control_boilerplate::SimHWInterface>,
+                       hardware_interface::RobotHW)


### PR DESCRIPTION
This creates an adapter class for ```GenericHWInterfaces``` which allows usage inside a ```combined_robot_hw```. This adapter is then used to export ```SimHWInterface```.

For demonstration, an additional rrbot demo is created. While creating this, some restructuring of ```rrbot_control``` was needed, which should reflect its function more clearly.

This starts as a draft, as i want to add more documentation and explore the possibility of a "generic" ```combined_robot_hw_runner``` node (or similar) in ```ros_control_boilerplate```.

Fixes #34. Continuation of #42.