### PR TITLE
Backport from noetic to kinetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ cache: ccache
 env:
   matrix:
     - ROS_DISTRO=kinetic
-    
+    # Don't run clang-format: Kinetic default version cannot handle moveit config
+    - ROS_DISTRO=kinetic TEST="catkin_lint"
+
 before_script:
     - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,18 @@
+# This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci package.
 sudo: required
-dist: trusty
-language: generic # Force travis to use its minimal image with default Python settings
-compiler:
-  - gcc
+dist: xenial  # distro used by Travis, moveit_ci uses the docker image's distro
+services:
+  - docker
+language: cpp
+compiler: gcc
+cache: ccache
+
 env:
-  global:
-    - CATKIN_WS=~/catkin_ws
-    - CATKIN_WS_SRC=${CATKIN_WS}/src
-    - CI_ROS_DISTRO="indigo"
-install:
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-rosdep python-catkin-tools
-  - sudo rosdep init
-  - rosdep update
-  # Use rosdep to install all dependencies (including ROS itself)
-  - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
+  matrix:
+    - ROS_DISTRO=kinetic
+    
+before_script:
+    - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
+
 script:
-  - source /opt/ros/$CI_ROS_DISTRO/setup.bash
-  - mkdir -p $CATKIN_WS_SRC
-  - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
-  - cd $CATKIN_WS
-  - catkin init
-  # Enable install space
-  #- catkin config --install
-  # Build [and Install] packages
-  - catkin build --limit-status-rate 0.1 --no-notify -DCMAKE_BUILD_TYPE=Release
-  # Build tests
-  - catkin build --limit-status-rate 0.1 --no-notify --make-args tests
-  # Run tests
-  - catkin run_tests
+  - .moveit_ci/travis.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,47 +2,49 @@ cmake_minimum_required(VERSION 2.8.3)
 project(ros_control_boilerplate)
 
 # C++ 11
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall ${CMAKE_CXX_FLAGS}")
+if(NOT "${CMAKE_CXX_STANDARD}")
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(catkin REQUIRED COMPONENTS
-  cmake_modules
-  hardware_interface
-  controller_manager
-  roscpp
-  control_msgs
-  trajectory_msgs
   actionlib
-  urdf
-  joint_limits_interface
-  transmission_interface
+  cmake_modules
+  control_msgs
   control_toolbox
-  std_msgs
-  sensor_msgs
+  controller_manager
+  hardware_interface
+  joint_limits_interface
+  roscpp
   rosparam_shortcuts
+  sensor_msgs
+  std_msgs
+  trajectory_msgs
+  transmission_interface
+  urdf
 )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Gflags REQUIRED)
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
 catkin_package(
   INCLUDE_DIRS
     include
   CATKIN_DEPENDS
-    hardware_interface
-    controller_manager
-    roscpp
+    actionlib
     control_msgs
-    trajectory_msgs
-    urdf
-    joint_limits_interface
-    transmission_interface
     control_toolbox
-    std_msgs
-    sensor_msgs
+    controller_manager
+    hardware_interface
+    joint_limits_interface
+    roscpp
     rosparam_shortcuts
+    sensor_msgs
+    std_msgs
+    trajectory_msgs
+    transmission_interface
+    urdf
   LIBRARIES
     generic_hw_control_loop
     generic_hw_interface
@@ -60,7 +62,9 @@ include_directories(
 )
 
 # Control loop
-add_library(generic_hw_control_loop src/generic_hw_control_loop.cpp)
+add_library(generic_hw_control_loop
+  src/generic_hw_control_loop.cpp
+)
 target_link_libraries(generic_hw_control_loop
   ${catkin_LIBRARIES}
 )
@@ -139,22 +143,22 @@ add_subdirectory(rrbot_control)
 
 # Install libraries
 install(TARGETS
+    controller_to_csv
+    csv_to_controller
     generic_hw_control_loop
     generic_hw_interface
     sim_hw_interface
-    controller_to_csv
-    csv_to_controller
   LIBRARY DESTINATION
     ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 
 # Install executables
 install(TARGETS
-    ${PROJECT_NAME}_sim_hw_main
-    ${PROJECT_NAME}_test_trajectory
     ${PROJECT_NAME}_controller_to_csv_main
     ${PROJECT_NAME}_csv_to_controller_main
     ${PROJECT_NAME}_keyboard_teleop
+    ${PROJECT_NAME}_sim_hw_main
+    ${PROJECT_NAME}_test_trajectory
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ Developed by [Dave Coleman](http://dav.ee/) at the University of Colorado Boulde
 
 <a href='https://ko-fi.com/A7182AMW' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi2.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
- * [![Build Status](https://travis-ci.org/davetcoleman/ros_control_boilerplate.svg)](https://travis-ci.org/davetcoleman/ros_control_boilerplate) Travis CI
- * [![Devel Job Status](http://jenkins.ros.org/buildStatus/icon?job=devel-indigo-ros_control_boilerplate)](http://jenkins.ros.org/job/devel-indigo-ros_control_boilerplate) Devel Job Status
- * [![Build Status](http://jenkins.ros.org/buildStatus/icon?job=ros-indigo-ros-control-boilerplate_binarydeb_trusty_amd64)](http://jenkins.ros.org/job/ros-indigo-ros-control-boilerplate_binarydeb_trusty_amd64/) AMD64 Debian Job Status
+ * [![Build Status](https://travis-ci.org/PickNikRobotics/ros_control_boilerplate.svg?branch=kinetic-devel)](https://travis-ci.org/PickNikRobotics/ros_control_boilerplate) Travis CI
+ * [![Devel Job Status](http://build.ros.org/buildStatus/icon?job=Kdev__ros_control_boilerplate__ubuntu_xenial_amd64)](http://build.ros.org/job/Kdev__ros_control_boilerplate__ubuntu_xenial_amd64/) Devel Job Status
 
 <img src="https://raw.githubusercontent.com/davetcoleman/ros_control_boilerplate/jade-devel/resources/screenshot.png"/>
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Special thanks to the following maintainers of this repo:
  - Dave Coleman (@davetcoleman)
  - Andy Zelenak (@AndyZe)
  - John Morris (@zultron)
+ - Robert Wilbrandt (@RobertWilbrandt)
 
 ## Status:
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Simple simulation interface and template for setting up a hardware interface for
  - Pass-through non-physics based robot simulator
  - Visualization in Rviz
 
-Developed by [Dave Coleman](http://dav.ee/) at the University of Colorado Boulder
+<img src="https://picknik.ai/assets/images/logo.jpg" width="120">
 
-<a href='https://ko-fi.com/A7182AMW' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi2.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+This open source project was developed at [PickNik Robotics](https://picknik.ai/). Need professional ROS development and consulting? Contact us at projects@picknik.ai for a free consultation.
+
+## Status:
 
  * [![Build Status](https://travis-ci.org/PickNikRobotics/ros_control_boilerplate.svg?branch=kinetic-devel)](https://travis-ci.org/PickNikRobotics/ros_control_boilerplate) Travis CI
  * [![Devel Job Status](http://build.ros.org/buildStatus/icon?job=Kdev__ros_control_boilerplate__ubuntu_xenial_amd64)](http://build.ros.org/job/Kdev__ros_control_boilerplate__ubuntu_xenial_amd64/) Devel Job Status

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Simple simulation interface and template for setting up a hardware interface for
 
 This open source project was developed at [PickNik Robotics](https://picknik.ai/). Need professional ROS development and consulting? Contact us at projects@picknik.ai for a free consultation.
 
+## Maintainers
+
+Special thanks to the following maintainers of this repo:
+
+ - Dave Coleman (@davetcoleman)
+ - Andy Zelenak (@AndyZe)
+ - John Morris (@zultron)
+
 ## Status:
 
  * [![Build Status](https://travis-ci.org/PickNikRobotics/ros_control_boilerplate.svg?branch=kinetic-devel)](https://travis-ci.org/PickNikRobotics/ros_control_boilerplate) Travis CI

--- a/include/ros_control_boilerplate/generic_hw_control_loop.h
+++ b/include/ros_control_boilerplate/generic_hw_control_loop.h
@@ -38,7 +38,8 @@
 */
 
 #include <time.h>
-#include <ros_control_boilerplate/generic_hw_interface.h>
+#include <controller_manager/controller_manager.h>
+#include <hardware_interface/robot_hw.h>
 
 namespace ros_control_boilerplate
 {
@@ -62,7 +63,7 @@ public:
    */
   GenericHWControlLoop(
       ros::NodeHandle& nh,
-      boost::shared_ptr<ros_control_boilerplate::GenericHWInterface> hardware_interface);
+      boost::shared_ptr<hardware_interface::RobotHW> hardware_interface);
 
   // Run the control loop (blocking)
   void run();
@@ -97,7 +98,7 @@ protected:
   boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
 
   /** \brief Abstract Hardware Interface for your robot */
-  boost::shared_ptr<ros_control_boilerplate::GenericHWInterface> hardware_interface_;
+  boost::shared_ptr<hardware_interface::RobotHW> hardware_interface_;
 
 };  // end class
 

--- a/include/ros_control_boilerplate/generic_hw_control_loop.h
+++ b/include/ros_control_boilerplate/generic_hw_control_loop.h
@@ -63,7 +63,7 @@ public:
    */
   GenericHWControlLoop(
       ros::NodeHandle& nh,
-      boost::shared_ptr<hardware_interface::RobotHW> hardware_interface);
+      std::shared_ptr<hardware_interface::RobotHW> hardware_interface);
 
   // Run the control loop (blocking)
   void run();
@@ -95,10 +95,10 @@ protected:
    * stopping ros_control-based controllers. It also serializes execution of all
    * running controllers in \ref update.
    */
-  boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
+  std::shared_ptr<controller_manager::ControllerManager> controller_manager_;
 
   /** \brief Abstract Hardware Interface for your robot */
-  boost::shared_ptr<hardware_interface::RobotHW> hardware_interface_;
+  std::shared_ptr<hardware_interface::RobotHW> hardware_interface_;
 
 };  // end class
 

--- a/include/ros_control_boilerplate/generic_hw_interface.h
+++ b/include/ros_control_boilerplate/generic_hw_interface.h
@@ -69,7 +69,7 @@ public:
    * \param nh - Node handle for topics.
    * \param urdf - optional pointer to a parsed robot model
    */
-  GenericHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model = NULL);
+  GenericHWInterface(const ros::NodeHandle &nh, urdf::Model *urdf_model = NULL);
 
   /** \brief Destructor */
   virtual ~GenericHWInterface() {}
@@ -158,7 +158,7 @@ public:
 protected:
 
   /** \brief Get the URDF XML from the parameter server */
-  virtual void loadURDF(ros::NodeHandle& nh, std::string param_name);
+  virtual void loadURDF(const ros::NodeHandle& nh, std::string param_name);
 
   // Short name of this class
   std::string name_;

--- a/include/ros_control_boilerplate/generic_hw_interface.h
+++ b/include/ros_control_boilerplate/generic_hw_interface.h
@@ -80,8 +80,34 @@ public:
   /** \brief Read the state from the robot hardware. */
   virtual void read(ros::Duration &elapsed_time) = 0;
 
+  /** \brief Read the state from the robot hardware
+   *
+   * \note This delegates RobotHW::read() calls to read()
+   *
+   * \param time The current time, currently unused
+   * \param period The time passed since the last call
+   */
+  virtual void read(const ros::Time& /*time*/, const ros::Duration& period) override
+  {
+    ros::Duration elapsed_time = period;
+    read(elapsed_time);
+  }
+
   /** \brief Write the command to the robot hardware. */
   virtual void write(ros::Duration &elapsed_time) = 0;
+
+  /** \brief Write the command to the robot hardware
+   *
+   * \note This delegates RobotHW::write() calls to \ref write()
+   *
+   * \param time The current time, currently unused
+   * \param period The time passed since the last call
+   */
+  virtual void write(const ros::Time& /*time*/, const ros::Duration& period) override
+  {
+    ros::Duration elapsed_time = period;
+    write(elapsed_time);
+  }
 
   /** \brief Set all members to default values */
   virtual void reset();

--- a/include/ros_control_boilerplate/generic_hw_interface.h
+++ b/include/ros_control_boilerplate/generic_hw_interface.h
@@ -40,9 +40,6 @@
 #ifndef GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H
 #define GENERIC_ROS_CONTROL_GENERIC_HW_INTERFACE_H
 
-// C++
-#include <boost/scoped_ptr.hpp>
-
 // ROS
 #include <ros/ros.h>
 #include <urdf/model.h>

--- a/include/ros_control_boilerplate/tools/controller_to_csv.h
+++ b/include/ros_control_boilerplate/tools/controller_to_csv.h
@@ -112,9 +112,9 @@ private:
 
 };  // end class
 
-// Create boost pointers for this class
-typedef boost::shared_ptr<ControllerToCSV> ControllerToCSVPtr;
-typedef boost::shared_ptr<const ControllerToCSV> ControllerToCSVConstPtr;
+// Create std pointers for this class
+typedef std::shared_ptr<ControllerToCSV> ControllerToCSVPtr;
+typedef std::shared_ptr<const ControllerToCSV> ControllerToCSVConstPtr;
 
 }  // end namespace
 

--- a/package.xml
+++ b/package.xml
@@ -46,6 +46,12 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>rosparam_shortcuts</run_depend>
 
+  <!-- These are needed if you want to run the rrbot simulation demo -->
+  <!--<run_depend>xacro</run_depend>-->
+  <!--<run_depend>robot_state_publisher</run_depend>-->
+  <!--<run_depend>rrbot_description</run_depend>-->
+  <!--<run_depend>rviz</run_depend>-->
+
   <export>
   </export>
 </package>

--- a/rrbot_control/launch/rrbot_test_trajectory.launch
+++ b/rrbot_control/launch/rrbot_test_trajectory.launch
@@ -11,7 +11,7 @@
     <!-- Load hardware interface -->
     <node name="test_trajectory" pkg="ros_control_boilerplate" type="test_trajectory"
           output="screen" launch-prefix="$(arg launch_prefix)">
-      <param name="action_topic" value="/rrbot/position_trajectory_controller/follow_joint_trajectory/"/>
+      <param name="trajectory_controller" value="position_trajectory_controller"/>
       <rosparam file="$(find ros_control_boilerplate)/rrbot_control/config/rrbot_controllers.yaml" command="load"/>
     </node>
 

--- a/rrbot_control/src/rrbot_hw_main.cpp
+++ b/rrbot_control/src/rrbot_hw_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
 
   // NOTE: We run the ROS loop in a separate thread as external calls such
   // as service callbacks to load controllers can block the (main) control loop
-  ros::AsyncSpinner spinner(2);
+  ros::AsyncSpinner spinner(3);
   spinner.start();
 
   // Create the hardware interface specific to your robot

--- a/rrbot_control/src/rrbot_hw_main.cpp
+++ b/rrbot_control/src/rrbot_hw_main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
   spinner.start();
 
   // Create the hardware interface specific to your robot
-  boost::shared_ptr<rrbot_control::RRBotHWInterface> rrbot_hw_interface
+  std::shared_ptr<rrbot_control::RRBotHWInterface> rrbot_hw_interface
     (new rrbot_control::RRBotHWInterface(nh));
   rrbot_hw_interface->init();
 

--- a/src/generic_hw_control_loop.cpp
+++ b/src/generic_hw_control_loop.cpp
@@ -45,7 +45,7 @@
 namespace ros_control_boilerplate
 {
 GenericHWControlLoop::GenericHWControlLoop(
-    ros::NodeHandle& nh, boost::shared_ptr<ros_control_boilerplate::GenericHWInterface> hardware_interface)
+    ros::NodeHandle& nh, boost::shared_ptr<hardware_interface::RobotHW> hardware_interface)
   : nh_(nh), hardware_interface_(hardware_interface)
 {
   // Create the controller manager
@@ -80,6 +80,7 @@ void GenericHWControlLoop::update()
   elapsed_time_ =
       ros::Duration(current_time_.tv_sec - last_time_.tv_sec + (current_time_.tv_nsec - last_time_.tv_nsec) / BILLION);
   last_time_ = current_time_;
+  ros::Time now = ros::Time::now();
   // ROS_DEBUG_STREAM_THROTTLE_NAMED(1, "generic_hw_main","Sampled update loop with elapsed
   // time " << elapsed_time_.toSec());
 
@@ -93,13 +94,13 @@ void GenericHWControlLoop::update()
   }
 
   // Input
-  hardware_interface_->read(elapsed_time_);
+  hardware_interface_->read(now, elapsed_time_);
 
   // Control
-  controller_manager_->update(ros::Time::now(), elapsed_time_);
+  controller_manager_->update(now, elapsed_time_);
 
   // Output
-  hardware_interface_->write(elapsed_time_);
+  hardware_interface_->write(now, elapsed_time_);
 }
 
 }  // namespace

--- a/src/generic_hw_control_loop.cpp
+++ b/src/generic_hw_control_loop.cpp
@@ -45,7 +45,7 @@
 namespace ros_control_boilerplate
 {
 GenericHWControlLoop::GenericHWControlLoop(
-    ros::NodeHandle& nh, boost::shared_ptr<hardware_interface::RobotHW> hardware_interface)
+    ros::NodeHandle& nh, std::shared_ptr<hardware_interface::RobotHW> hardware_interface)
   : nh_(nh), hardware_interface_(hardware_interface)
 {
   // Create the controller manager

--- a/src/generic_hw_interface.cpp
+++ b/src/generic_hw_interface.cpp
@@ -44,7 +44,7 @@
 
 namespace ros_control_boilerplate
 {
-GenericHWInterface::GenericHWInterface(ros::NodeHandle &nh, urdf::Model *urdf_model)
+GenericHWInterface::GenericHWInterface(const ros::NodeHandle &nh, urdf::Model *urdf_model)
   : name_("generic_hw_interface")
   , nh_(nh)
   , use_rosparam_joint_limits_(false)
@@ -301,7 +301,7 @@ std::string GenericHWInterface::printCommandHelper()
   return ss.str();
 }
 
-void GenericHWInterface::loadURDF(ros::NodeHandle &nh, std::string param_name)
+void GenericHWInterface::loadURDF(const ros::NodeHandle &nh, std::string param_name)
 {
   std::string urdf_string;
   urdf_model_ = new urdf::Model();

--- a/src/sim_hw_main.cpp
+++ b/src/sim_hw_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
 
   // NOTE: We run the ROS loop in a separate thread as external calls such
   // as service callbacks to load controllers can block the (main) control loop
-  ros::AsyncSpinner spinner(2);
+  ros::AsyncSpinner spinner(3);
   spinner.start();
 
   // Create the hardware interface specific to your robot

--- a/src/sim_hw_main.cpp
+++ b/src/sim_hw_main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
   spinner.start();
 
   // Create the hardware interface specific to your robot
-  boost::shared_ptr<ros_control_boilerplate::SimHWInterface> sim_hw_interface
+  std::shared_ptr<ros_control_boilerplate::SimHWInterface> sim_hw_interface
     (new ros_control_boilerplate::SimHWInterface(nh));
   sim_hw_interface->init();
 

--- a/src/tools/test_trajectory.cpp
+++ b/src/tools/test_trajectory.cpp
@@ -57,21 +57,21 @@ public:
   TestTrajectory()
     : nh_private_("~")
   {
-    std::string action_topic;
-    nh_private_.getParam("action_topic", action_topic);
-    if (action_topic.empty())
+    nh_private_.getParam("trajectory_controller", trajectory_controller);
+    if (trajectory_controller.empty())
     {
       ROS_FATAL_STREAM_NAMED(
           "test_trajectory",
-          "Not follow joint trajectory action topic found on the parameter server");
+          "No joint trajectory controller parameter found on the parameter server");
       exit(-1);
     }
-    ROS_INFO_STREAM_NAMED("test_trajectory", "Connecting to action " << action_topic);
+    ROS_INFO_STREAM_NAMED("test_trajectory",
+                          "Connecting to controller " << trajectory_controller);
 
     // create the action client
     // true causes the client to spin its own thread
     actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> action_client(
-        action_topic, true);
+      trajectory_controller + "/follow_joint_trajectory/", true);
 
     ROS_INFO_NAMED("test_trajetory", "Waiting for action server to start.");
     // wait for the action server to start
@@ -111,7 +111,7 @@ public:
     double max_joint_value = 3.14;
 
     // Get joint names
-    nh_private_.getParam("hardware_interface/joints", joint_names);
+    nh_private_.getParam(trajectory_controller + "/joints", joint_names);
     if (joint_names.size() == 0)
     {
       ROS_FATAL_STREAM_NAMED(
@@ -157,6 +157,10 @@ public:
 private:
   // A shared node handle
   ros::NodeHandle nh_private_;
+
+  // A string containing the 'trajectory_controller' parameter value
+  std::string trajectory_controller;
+
 
 };  // end class
 

--- a/src/tools/test_trajectory.cpp
+++ b/src/tools/test_trajectory.cpp
@@ -162,9 +162,9 @@ private:
   std::string trajectory_controller;
 };  // end class
 
-// Create boost pointers for this class
-typedef boost::shared_ptr<TestTrajectory> TestTrajectoryPtr;
-typedef boost::shared_ptr<const TestTrajectory> TestTrajectoryConstPtr;
+// Create std pointers for this class
+typedef std::shared_ptr<TestTrajectory> TestTrajectoryPtr;
+typedef std::shared_ptr<const TestTrajectory> TestTrajectoryConstPtr;
 
 }  // end namespace
 

--- a/src/tools/test_trajectory.cpp
+++ b/src/tools/test_trajectory.cpp
@@ -160,8 +160,6 @@ private:
 
   // A string containing the 'trajectory_controller' parameter value
   std::string trajectory_controller;
-
-
 };  // end class
 
 // Create boost pointers for this class


### PR DESCRIPTION
Rebase all non-distribution related commits (e.g. changelogs, noetic migration, ...) from ```noetic-devel``` to ```kinetic-devel``` while preserving merge structure and referencing original commits.

Some things that i was not 100% sure about:
- I removed the kinetic debian build badge from the README, as that target doesn't seem to get built anymore (while looking for it i began to wonder if it ever existed)
- The ```boost::shared_ptr``` to ```std::shared_ptr```changes seemed to build fine in my docker images, as this package already used c++11 before

I tested the basic operation of this in docker (e.g. using the ```rrbot```examples)  and updated the travis configs.

@JafarAbdi could you take a look at this as a basis for a new kinetic release?