### PR TITLE
[ROS-O] drop obsolete cmake standard definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(ros_control_boilerplate)
 
-# C++ 11
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 11)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 find_package(catkin REQUIRED COMPONENTS
   actionlib
   cmake_modules


### PR DESCRIPTION
To make the default build run on modern systems.